### PR TITLE
UF-9976 - Set reply-to on outgoing e-mails

### DIFF
--- a/src/integration-test/java/apptest/ArchiveSchedulerTest.java
+++ b/src/integration-test/java/apptest/ArchiveSchedulerTest.java
@@ -1,19 +1,18 @@
 package apptest;
 
-import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.verify;
-
-import java.time.Duration;
-
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.TestPropertySource;
-
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import se.sundsvall.byggrarchiver.Application;
 import se.sundsvall.byggrarchiver.service.scheduler.ArchiverScheduler;
 import se.sundsvall.dept44.test.AbstractAppTest;
 import se.sundsvall.dept44.test.annotation.wiremock.WireMockAppTestSuite;
+
+import java.time.Duration;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
 
 @WireMockAppTestSuite(
 	files = "classpath:/IntegrationTest/",
@@ -22,7 +21,7 @@ import se.sundsvall.dept44.test.annotation.wiremock.WireMockAppTestSuite;
 @TestPropertySource(properties = {"scheduler.cron.expression=* * * ? * *"})
 class ArchiveSchedulerTest extends AbstractAppTest {
 
-	@SpyBean
+	@MockitoSpyBean
 	private ArchiverScheduler archiverScheduler;
 
 	@Test

--- a/src/main/java/se/sundsvall/byggrarchiver/configuration/EmailProperties.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/configuration/EmailProperties.java
@@ -16,8 +16,5 @@ public record EmailProperties(
 
 	@Valid @NotNull Instance status) {
 
-	public record Instance(@NotBlank String sender, @NotBlank String recipient) {
-
-	}
-
+	public record Instance(@NotBlank String sender, String replyTo, @NotBlank String recipient) {}
 }

--- a/src/main/java/se/sundsvall/byggrarchiver/integration/messaging/MessagingMapper.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/integration/messaging/MessagingMapper.java
@@ -2,6 +2,7 @@ package se.sundsvall.byggrarchiver.integration.messaging;
 
 import generated.se.sundsvall.messaging.EmailRequest;
 import generated.se.sundsvall.messaging.EmailSender;
+import se.sundsvall.byggrarchiver.configuration.EmailProperties;
 
 public final class MessagingMapper {
 
@@ -11,17 +12,17 @@ public final class MessagingMapper {
 		// Prevent instantiation
 	}
 
-	static EmailRequest toEmailRequest(final String sender, final String htmlMessage, final String recipient, final String subject) {
-		return new EmailRequest().sender(toEmailSender(sender))
-			.emailAddress(recipient)
+	static EmailRequest toEmailRequest(final EmailProperties.Instance emailProperties, final String subject, final String htmlMessage) {
+		return new EmailRequest().sender(toEmailSender(emailProperties))
+			.emailAddress(emailProperties.recipient())
 			.subject(subject)
 			.htmlMessage(htmlMessage);
 	}
 
-	static EmailSender toEmailSender(final String sender) {
+	static EmailSender toEmailSender(final EmailProperties.Instance emailProperties) {
 		return new EmailSender()
 			.name(BYGGR_ARCHIVER_SENDER)
-			.address(sender);
+			.address(emailProperties.sender())
+			.replyTo(emailProperties.replyTo());
 	}
-
 }

--- a/src/test/java/se/sundsvall/byggrarchiver/integration/messaging/MessagingIntegrationTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/integration/messaging/MessagingIntegrationTest.java
@@ -5,7 +5,6 @@ import static generated.se.sundsvall.messaging.MessageType.EMAIL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -30,7 +29,7 @@ class MessagingIntegrationTest {
 
 	private static final String MUNICIPALITY_ID = "2281";
 
-	private final EmailProperties.Instance instance = new EmailProperties.Instance("someSender", "someRecipient");
+	private final EmailProperties.Instance instance = new EmailProperties.Instance("someSender", "someReplyTo", "someRecipient");
 
 	@Mock
 	private MessagingClient mockClient;
@@ -55,7 +54,7 @@ class MessagingIntegrationTest {
 
 		messagingIntegration.sendExtensionErrorEmail(new ArchiveHistory(), MUNICIPALITY_ID);
 
-		verify(mockEmailProperties, times(2)).extensionError();
+		verify(mockEmailProperties).extensionError();
 		verifyNoMoreInteractions(mockEmailProperties);
 		verify(mockClient).sendEmail(eq(MUNICIPALITY_ID), any(EmailRequest.class));
 		verifyNoMoreInteractions(mockClient);
@@ -73,13 +72,13 @@ class MessagingIntegrationTest {
 						.messageType(EMAIL)
 						.status(SENT))));
 
-		final var archiveHistory = new ArchiveHistory();
+		var archiveHistory = new ArchiveHistory();
 		archiveHistory.setArchiveStatus(COMPLETED);
-		final var archiveHistories = List.of(archiveHistory);
+		var archiveHistories = List.of(archiveHistory);
 
 		messagingIntegration.sendStatusMail(archiveHistories, 1L, MUNICIPALITY_ID);
 
-		verify(mockEmailProperties, times(2)).status();
+		verify(mockEmailProperties).status();
 		verifyNoMoreInteractions(mockEmailProperties);
 		verify(mockClient).sendEmail(eq(MUNICIPALITY_ID), any(EmailRequest.class));
 		verifyNoMoreInteractions(mockClient);
@@ -99,7 +98,7 @@ class MessagingIntegrationTest {
 
 		messagingIntegration.sendEmailToLantmateriet("somePropertyDesignation", new ArchiveHistory(), MUNICIPALITY_ID);
 
-		verify(mockEmailProperties, times(2)).lantmateriet();
+		verify(mockEmailProperties).lantmateriet();
 		verifyNoMoreInteractions(mockEmailProperties);
 		verify(mockClient).sendEmail(eq(MUNICIPALITY_ID), any(EmailRequest.class));
 		verifyNoMoreInteractions(mockClient);
@@ -109,5 +108,4 @@ class MessagingIntegrationTest {
 	void test_replace() {
 		assertThat(messagingIntegration.replace("hello ${name}", Map.of("name", "Bob"))).isEqualTo("hello Bob");
 	}
-
 }


### PR DESCRIPTION
Adds handling of the (optional) reply-to address on outgoing e-mails.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
