### PR TITLE
feat: add archive failure audit log (fallout table)

### DIFF
--- a/src/integration-test/java/apptest/IntegrationTest.java
+++ b/src/integration-test/java/apptest/IntegrationTest.java
@@ -12,6 +12,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.BatchTrigger.SCHEDULED;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.ARCHIVE_REJECTED_FORMAT;
 import static se.sundsvall.byggrarchiver.testutils.TestUtil.randomInt;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import se.sundsvall.byggrarchiver.Application;
 import se.sundsvall.byggrarchiver.api.model.BatchJob;
+import se.sundsvall.byggrarchiver.integration.db.ArchiveFailureRepository;
 import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
 import se.sundsvall.byggrarchiver.integration.db.BatchHistoryRepository;
 import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
@@ -52,6 +54,9 @@ class IntegrationTest extends AbstractAppTest {
 	@Autowired
 	private BatchHistoryRepository batchHistoryRepository;
 
+	@Autowired
+	private ArchiveFailureRepository archiveFailureRepository;
+
 	@BeforeEach
 	void beforeEach() {
 		wiremock.resetAll();
@@ -59,6 +64,7 @@ class IntegrationTest extends AbstractAppTest {
 		// Clear db between tests
 		archiveHistoryRepository.deleteAll();
 		batchHistoryRepository.deleteAll();
+		archiveFailureRepository.deleteAll();
 	}
 
 	// POST batch and then GET batch history and archive histories - verify that the correct is returned
@@ -310,6 +316,42 @@ class IntegrationTest extends AbstractAppTest {
 			.withStart(LocalDate.now())
 			.withEnd(LocalDate.now())
 			.build());
+	}
+
+	// Batch where one document is rejected by the archive service (HTTP 500 "File format validation failed.") while the
+	// rest archive OK - verify one document is COMPLETED and that the rejection is recorded in the archive_failure table.
+	@Test
+	void test14_failingBatch() throws JsonProcessingException, ClassNotFoundException {
+		// Fixed date window whose GetUpdatedArenden fixture has BatchEnd == the window end, so the batch loop runs only
+		// two passes (avoids the failing document being re-archived enough times to trip the archive circuit breaker).
+		final var postBatchHistory = postBatchJob(BatchJob.builder()
+			.withStart(LocalDate.parse("2021-12-17"))
+			.withEnd(LocalDate.parse("2021-12-17"))
+			.build());
+
+		final var archiveHistories = archiveHistoryRepository.getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(postBatchHistory.getId(), MUNICIPALITY_ID);
+
+		// One document (431169) archived successfully, while the keyed document (433467) was rejected and not completed
+		assertThat(archiveHistories)
+			.anySatisfy(archiveHistory -> {
+				assertThat(archiveHistory.getDocumentId()).isEqualTo("431169");
+				assertThat(archiveHistory.getArchiveStatus()).isEqualTo(COMPLETED);
+			})
+			.anySatisfy(archiveHistory -> {
+				assertThat(archiveHistory.getDocumentId()).isEqualTo("433467");
+				assertThat(archiveHistory.getArchiveStatus()).isEqualTo(NOT_COMPLETED);
+			});
+
+		// The rejection was recorded in the append-only audit table
+		final var archiveFailures = archiveFailureRepository.findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(postBatchHistory.getId(), MUNICIPALITY_ID, null);
+
+		assertThat(archiveFailures)
+			.isNotEmpty()
+			.allSatisfy(archiveFailure -> {
+				assertThat(archiveFailure.getDocumentId()).isEqualTo("433467");
+				assertThat(archiveFailure.getCaseId()).isEqualTo("BYGG 2018-000026");
+				assertThat(archiveFailure.getFailureCategory()).isEqualTo(ARCHIVE_REJECTED_FORMAT);
+			});
 	}
 
 	private BatchHistory postBatchJob(final BatchJob batchJob) throws JsonProcessingException, ClassNotFoundException {

--- a/src/integration-test/java/apptest/IntegrationTest.java
+++ b/src/integration-test/java/apptest/IntegrationTest.java
@@ -13,6 +13,7 @@ import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.BatchTrigger.SCHEDULED;
 import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.ARCHIVE_REJECTED_FORMAT;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.BYGGR_FETCH_ERROR;
 import static se.sundsvall.byggrarchiver.testutils.TestUtil.randomInt;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import se.sundsvall.byggrarchiver.Application;
+import se.sundsvall.byggrarchiver.api.model.ArchiveFailureResponse;
 import se.sundsvall.byggrarchiver.api.model.BatchJob;
 import se.sundsvall.byggrarchiver.integration.db.ArchiveFailureRepository;
 import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
@@ -351,6 +353,68 @@ class IntegrationTest extends AbstractAppTest {
 				assertThat(archiveFailure.getDocumentId()).isEqualTo("433467");
 				assertThat(archiveFailure.getCaseId()).isEqualTo("BYGG 2018-000026");
 				assertThat(archiveFailure.getFailureCategory()).isEqualTo(ARCHIVE_REJECTED_FORMAT);
+			});
+
+		// ... and is readable through the fallout endpoint
+		final var fallout = setupCall()
+			.withHttpMethod(GET)
+			.withServicePath(BATCH_PATH + "/" + postBatchHistory.getId() + "/fallout")
+			.withExpectedResponseStatus(OK)
+			.sendRequestAndVerifyResponse()
+			.andReturnBody(ArchiveFailureResponse[].class);
+
+		assertThat(fallout)
+			.isNotEmpty()
+			.allSatisfy(archiveFailure -> {
+				assertThat(archiveFailure.getBatchHistoryId()).isEqualTo(postBatchHistory.getId());
+				assertThat(archiveFailure.getDocumentId()).isEqualTo("433467");
+				assertThat(archiveFailure.getCaseId()).isEqualTo("BYGG 2018-000026");
+				assertThat(archiveFailure.getFailureCategory()).isEqualTo(ARCHIVE_REJECTED_FORMAT);
+			});
+
+		// The category filter excludes non-matching categories
+		final var noFileTooLargeFallout = setupCall()
+			.withHttpMethod(GET)
+			.withServicePath(BATCH_PATH + "/" + postBatchHistory.getId() + "/fallout?category=FILE_TOO_LARGE")
+			.withExpectedResponseStatus(OK)
+			.sendRequestAndVerifyResponse()
+			.andReturnBody(ArchiveFailureResponse[].class);
+
+		assertThat(noFileTooLargeFallout).isEmpty();
+	}
+
+	// One document's GetDocument call faults (ByggR SOAP 500). It must be recorded as BYGGR_FETCH_ERROR and must NOT
+	// abort the batch - the other document still archives successfully.
+	@Test
+	void test15_byggrFetchError() throws JsonProcessingException, ClassNotFoundException {
+		// Same fixed window as test14 so the batch loop runs only two passes (keeps the repeated fetch faults below the
+		// arendeexport circuit breaker threshold).
+		final var postBatchHistory = postBatchJob(BatchJob.builder()
+			.withStart(LocalDate.parse("2021-12-17"))
+			.withEnd(LocalDate.parse("2021-12-17"))
+			.build());
+
+		final var archiveHistories = archiveHistoryRepository.getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(postBatchHistory.getId(), MUNICIPALITY_ID);
+
+		// The batch was not aborted: the other document archived OK, while the one whose fetch failed is not completed
+		assertThat(archiveHistories)
+			.anySatisfy(archiveHistory -> {
+				assertThat(archiveHistory.getDocumentId()).isEqualTo("431169");
+				assertThat(archiveHistory.getArchiveStatus()).isEqualTo(COMPLETED);
+			})
+			.anySatisfy(archiveHistory -> {
+				assertThat(archiveHistory.getDocumentId()).isEqualTo("433467");
+				assertThat(archiveHistory.getArchiveStatus()).isEqualTo(NOT_COMPLETED);
+			});
+
+		// The fetch failure was recorded as BYGGR_FETCH_ERROR
+		final var archiveFailures = archiveFailureRepository.findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(postBatchHistory.getId(), MUNICIPALITY_ID, null);
+
+		assertThat(archiveFailures)
+			.isNotEmpty()
+			.allSatisfy(archiveFailure -> {
+				assertThat(archiveFailure.getDocumentId()).isEqualTo("433467");
+				assertThat(archiveFailure.getFailureCategory()).isEqualTo(BYGGR_FETCH_ERROR);
 			});
 	}
 

--- a/src/integration-test/resources/IntegrationTest/__files/test14_failingBatch/mappings/archive-500-fileformat.json
+++ b/src/integration-test/resources/IntegrationTest/__files/test14_failingBatch/mappings/archive-500-fileformat.json
@@ -1,0 +1,19 @@
+{
+	"priority": 1,
+	"request": {
+		"method": "POST",
+		"urlPath": "/archive/2.0/2281/archive/byggr",
+		"bodyPatterns": [
+			{
+				"contains": "<Rubrik>Bilaga</Rubrik>"
+			}
+		]
+	},
+	"response": {
+		"headers": {
+			"Content-Type": "application/problem+json"
+		},
+		"bodyFileName": "test14_failingBatch/response/archive500FileFormat.json",
+		"status": 500
+	}
+}

--- a/src/integration-test/resources/IntegrationTest/__files/test14_failingBatch/mappings/arendeexport.GetUpdatedArenden.200.json
+++ b/src/integration-test/resources/IntegrationTest/__files/test14_failingBatch/mappings/arendeexport.GetUpdatedArenden.200.json
@@ -1,0 +1,27 @@
+{
+	"priority": 1,
+	"request": {
+		"method": "POST",
+		"url": "/TekisArende/ArendeExportWS.svc",
+		"bodyPatterns": [
+			{
+				"and": [
+					{
+						"contains": "GetUpdatedArenden"
+					},
+					{
+						"contains": "UpperInclusiveBound>2021-12-17T23:59:59"
+					}
+				]
+			}
+		]
+	},
+	"response": {
+		"headers": {
+			"Server": "Microsoft-IIS/10.0",
+			"Content-Type": "text/xml; charset=utf-8"
+		},
+		"bodyFileName": "test14_failingBatch/response/arendeexport.GetUpdatedArenden.200.xml",
+		"status": 200
+	}
+}

--- a/src/integration-test/resources/IntegrationTest/__files/test14_failingBatch/response/archive500FileFormat.json
+++ b/src/integration-test/resources/IntegrationTest/__files/test14_failingBatch/response/archive500FileFormat.json
@@ -1,0 +1,5 @@
+{
+	"detail": "[500 Internal Server Error] during [POST] to [http://sdas026.sundsvall.se:8088/api/import] [FormpipeProxyClient#postImport(ImportRequest)]: [{\"Message\":\"File format validation failed.\"}]",
+	"status": 500,
+	"title": "Internal Server Error"
+}

--- a/src/integration-test/resources/IntegrationTest/__files/test14_failingBatch/response/arendeexport.GetUpdatedArenden.200.xml
+++ b/src/integration-test/resources/IntegrationTest/__files/test14_failingBatch/response/arendeexport.GetUpdatedArenden.200.xml
@@ -1,0 +1,1561 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+	<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	>
+		<GetUpdatedArendenResponse xmlns="www.tekis.se/ServiceContract">
+			<GetUpdatedArendenResult>
+				<BatchStart>2021-12-17T00:00:00</BatchStart>
+				<BatchEnd>2021-12-17T23:59:59</BatchEnd>
+				<Arenden>
+					<arende arendeId="55522" dnr="BYGG 2021-000771" diarieprefix="BYGG"
+							kommun="Sundsvall" enhet="SBK"
+							enhetkod="" arendegrupp="LOV" arendetyp="BL" arendeslag="A"
+							arendeklass="LB" namndkod="SBN"
+							kalla="3">
+						<status xmlns="www.tekis.se/arende">Pågående</status>
+						<beskrivning xmlns="www.tekis.se/arende">Bygglov för nybyggnad av
+							lagerbyggnad, parkering &amp;
+							småbåtshamn
+						</beskrivning>
+						<ankomstDatum xmlns="www.tekis.se/arende">2021-12-16</ankomstDatum>
+						<uppdateradDatum xmlns="www.tekis.se/arende">2021-12-16</uppdateradDatum>
+						<registreradDatum xmlns="www.tekis.se/arende">2021-12-16</registreradDatum>
+						<handlaggare handlaggareId="-1" signatur="" xmlns="www.tekis.se/arende">
+							<fornamn/>
+							<efternamn/>
+						</handlaggare>
+						<intressentLista xmlns="www.tekis.se/arende">
+							<intressent intressentId="36552" attentionId="11858"
+										arForetag="true" intressentVersionId="56522">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress>co adress</coAdress>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn/>
+								<efternamn/>
+								<attention>attention</attention>
+								<rollLista>
+									<roll>SOK</roll>
+								</rollLista>
+							</intressent>
+							<intressent intressentId="36540" attentionId="0"
+										intressentVersionId="56524">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress>annan kontakt co</coAdress>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn/>
+								<efternamn/>
+								<attention/>
+								<rollLista>
+									<roll>BETA</roll>
+								</rollLista>
+							</intressent>
+							<intressent intressentId="36535" attentionId="0"
+										intressentVersionId="56523">
+								<namn>Test Testorsson</namn>
+								<adress/>
+								<coAdress/>
+								<postNr/>
+								<ort/>
+								<land/>
+								<fornamn/>
+								<efternamn/>
+								<attention/>
+								<rollLista>
+									<roll>KPER</roll>
+								</rollLista>
+							</intressent>
+						</intressentLista>
+						<handelseLista xmlns="www.tekis.se/arende">
+							<handelse handelseId="362923" checksum="60">
+								<riktning>In</riktning>
+								<rubrik>Bygglov</rubrik>
+								<startDatum>2021-12-16T08:16:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>Bygglov</handelseslag>
+								<handelsetyp>ANSÖKAN</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="434978" checksum="60">
+										<typ>ANS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>8902.pdf</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586443" checksum="-1243540383">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434979" checksum="60">
+										<typ>SITU</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>situationsplan Ritning1.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586444" checksum="-1933202738">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434980" checksum="61">
+										<typ>SEK2</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>sektionsritning Ritning3.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586445" checksum="1718795407">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434981" checksum="61">
+										<typ>RITNING</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>ritning Ritning3.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586446" checksum="-1268635663">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434982" checksum="61">
+										<typ>PLA2</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>planritning Ritning2.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586447" checksum="-1189009869">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434983" checksum="61">
+										<typ>NYKA</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>nybyggnadskarta Ritning1.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586448" checksum="-908427253">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434984" checksum="62">
+										<typ>FÖRK</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>kontrollplan Kontrollplan.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586449" checksum="702710784">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434985" checksum="62">
+										<typ>UKON</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>konstruktionsritning Ritning2.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586450" checksum="1772255952">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434986" checksum="62">
+										<typ>UKON</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>konstruktionshandling Ritning1.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586451" checksum="2070134623">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434987" checksum="62">
+										<typ>UKON</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>konstruktionshandling Fullmakt.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586452" checksum="-1379204737">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434988" checksum="62">
+										<typ>ANMÄ</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>kauppgifter KA uppgifter.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586453" checksum="-59093652">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434989" checksum="63">
+										<typ>FUM</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>fullmakt Fullmakt.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586454" checksum="-485473024">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434990" checksum="63">
+										<typ>FAS2</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>fasadritning Fasad väst.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586455" checksum="677502436">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434991" checksum="63">
+										<typ>FAS2</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>fasadritning Fasad ost.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586456" checksum="-77536153">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="SYSTEM"/>
+							</handelse>
+							<handelse handelseId="362924" checksum="63">
+								<riktning>In</riktning>
+								<rubrik>Manuell hantering</rubrik>
+								<startDatum>2021-12-16T08:16:00+01:00</startDatum>
+								<anteckning>Det finns uppgifter om kontrollansvarig i handlingen
+									"Ansökan om bygglov".
+									Du måste registrera denna typ av intressenter manuellt.
+								</anteckning>
+								<handelseslag>MANHANT</handelseslag>
+								<handelsetyp>STATUS</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="SYSTEM"/>
+							</handelse>
+						</handelseLista>
+						<projektnr xmlns="www.tekis.se/arende">TEST 1:9</projektnr>
+						<objektLista xmlns="www.tekis.se/arende">
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="56360"
+												  arHuvudObjekt="true"
+												  checksum="1|">
+								<fastighet checksum="-137380678|" fnr="22044360">
+									<trakt>TEST</trakt>
+									<fbetNr>1:9</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+						</objektLista>
+					</arende>
+					<arende arendeId="51828" dnr="BYGG 2020-001012" diarieprefix="BYGG"
+							kommun="Sundsvall" enhet="SBK"
+							enhetkod="" arendegrupp="LOV" arendetyp="ANM" arendeslag="C"
+							arendeklass="EB" namndkod="SBN"
+							kalla="1">
+						<status xmlns="www.tekis.se/arende">Pågående</status>
+						<beskrivning xmlns="www.tekis.se/arende">Anmälan för installation av eldstad
+							och rökkanal
+							enbostadshus
+						</beskrivning>
+						<ankomstDatum xmlns="www.tekis.se/arende">2020-07-02</ankomstDatum>
+						<uppdateradDatum xmlns="www.tekis.se/arende">2021-12-16</uppdateradDatum>
+						<registreradDatum xmlns="www.tekis.se/arende">2020-07-10</registreradDatum>
+						<handlaggare handlaggareId="1602" signatur="maj27nym"
+									 xmlns="www.tekis.se/arende">
+							<fornamn>Test</fornamn>
+							<fornamn>Testorsson</fornamn>
+						</handlaggare>
+						<intressentLista xmlns="www.tekis.se/arende">
+							<intressent intressentId="27055" attentionId="10277"
+										arForetag="true" intressentVersionId="38853">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn/>
+								<efternamn/>
+								<attention>Kontakt</attention>
+								<rollLista>
+									<roll>KPER</roll>
+								</rollLista>
+							</intressent>
+							<intressent intressentId="14743" attentionId="0"
+										intressentVersionId="53487">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn>Test</fornamn>
+								<fornamn>Testorsson</fornamn>
+								<attention/>
+								<rollLista>
+									<roll>FAG</roll>
+									<roll>SOK</roll>
+								</rollLista>
+							</intressent>
+						</intressentLista>
+						<handelseLista xmlns="www.tekis.se/arende">
+							<handelse handelseId="344948" checksum="15">
+								<riktning>Okänd</riktning>
+								<rubrik>Fastställd kontrollplan</rubrik>
+								<startDatum>2020-08-14T11:29:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>GBCA</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="false">
+									<beslutstext/>
+									<delegatHandlaggare signatur="hel07sah">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="415644" checksum="2">
+										<typ>FAST</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-08-14</handlingDatum>
+										<uuid>5e2b482f-b342-454c-be51-ab80beac050f</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="567085" checksum="1827264204">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Fastställd kontrollplan</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="344780" checksum="36">
+								<riktning>Ut</riktning>
+								<rubrik>Ärende komplett</rubrik>
+								<startDatum>2020-08-13T13:34:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>Komplett</handelseslag>
+								<handelsetyp>STATUS</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="sus11ost"/>
+							</handelse>
+							<handelse handelseId="344946" checksum="45">
+								<riktning>Okänd</riktning>
+								<rubrik>Startbesked</rubrik>
+								<startDatum>2020-08-14T11:23:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>GAAC</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut beslutNr="IN 2020-000833" arHuvudbeslut="true">
+									<beslutstext/>
+									<delegatHandlaggare signatur="hel07sah">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="413207" checksum="55">
+										<typ>ANM</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-07-02</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="564552" checksum="-196680004">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Anmälan</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="415497" checksum="56">
+										<typ>FAS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566936" checksum="-565850922">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="415500" checksum="57">
+										<typ>PLA</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566939" checksum="880137261">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="415501" checksum="57">
+										<typ>PRES</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566940" checksum="1475912738">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="415643" checksum="2">
+										<typ>STAB</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-08-14</handlingDatum>
+										<uuid>4b06e108-571b-4354-b300-f4bc0ad7ae80</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="567084" checksum="-188279055">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Startbesked</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="sus11ost"/>
+							</handelse>
+							<handelse handelseId="348409" checksum="41">
+								<riktning>Ut</riktning>
+								<rubrik>Slutbesked</rubrik>
+								<startDatum>2020-09-22T09:54:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>SLU</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="false">
+									<beslutstext/>
+									<delegatHandlaggare signatur="mik23kal">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="419506" checksum="41">
+										<typ>SBES</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2020-09-22</handlingDatum>
+										<uuid>72e9455e-147c-4960-a6d8-b47d86fa1af8</uuid>
+										<arkivStatus>Arkiveras</arkivStatus>
+										<makulerad>false</makulerad>
+										<dokument dokId="571054" checksum="-1342627291">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Slutbesked</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="342498" checksum="41">
+								<riktning>In</riktning>
+								<rubrik>Eldstad/Rökkanal</rubrik>
+								<startDatum>2020-07-02T00:00:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>ELD</handelseslag>
+								<handelsetyp>ANM</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="413207" checksum="55">
+										<typ>ANM</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-07-02</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="564552" checksum="-196680004">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Anmälan</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="sus11ost"/>
+							</handelse>
+							<handelse handelseId="342542" checksum="50">
+								<riktning>Okänd</riktning>
+								<rubrik>Bekräftelse skickad</rubrik>
+								<startDatum>2020-07-10T17:03:00+02:00</startDatum>
+								<anteckning>Mottagargrupp:
+									Kontakt:
+									Skickade e-post till info@eldstaden.com - Utskick Kontakt 1.eml
+
+									Olof Näsman:
+									Skickade e-post till ollenasman@yahoo.se - Utskick Olof Näsman
+									1.eml
+
+
+								</anteckning>
+								<handelseslag>Kv</handelseslag>
+								<handelsetyp>Atom</handelsetyp>
+								<handelseutfall>Kv4</handelseutfall>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>true</arbetsmaterial>
+								<handlaggare signatur="Atom"/>
+							</handelse>
+							<handelse handelseId="344254" checksum="8">
+								<riktning>Okänd</riktning>
+								<rubrik>Kompletteringsföreläggande - skickat</rubrik>
+								<startDatum>2020-08-07T17:07:00+02:00</startDatum>
+								<anteckning>Mottagargrupp:
+									Kontakt:
+									Skickade e-post till info@eldstaden.com - Utskick Kontakt 1.eml
+
+									Olof Näsman:
+									Skickade e-post till ollenasman@yahoo.se - Utskick Olof Näsman
+									1.eml
+
+
+									Ärendebevakning SvarKompl skapades för ärende BYGG 2020-001012
+									kopplad till
+									handläggare Atom
+								</anteckning>
+								<handelseslag>Kv</handelseslag>
+								<handelsetyp>Atom</handelsetyp>
+								<handelseutfall>Kv11</handelseutfall>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>true</arbetsmaterial>
+								<handlaggare signatur="Atom"/>
+							</handelse>
+							<handelse handelseId="344950" checksum="47">
+								<riktning>Ut</riktning>
+								<rubrik>Anmälan</rubrik>
+								<startDatum>2020-08-14T11:31:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>ANM</handelseslag>
+								<handelsetyp>DEBIT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="344951" checksum="12">
+								<riktning>Ut</riktning>
+								<rubrik>Digitalt utskick av beslut</rubrik>
+								<startDatum>2020-08-14T11:31:00+02:00</startDatum>
+								<anteckning>Hej,
+
+									Här kommer ditt beslut.
+
+									Med vänlig hälsning
+
+									Sundsvalls Kommun
+									Stadsbyggnadskontoret
+									Bygglovavdelningen
+								</anteckning>
+								<handelseslag>DIGI</handelseslag>
+								<handelsetyp>DIG</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="415643" checksum="2">
+										<typ>STAB</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-08-14</handlingDatum>
+										<uuid>4b06e108-571b-4354-b300-f4bc0ad7ae80</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="567084" checksum="-188279055">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Startbesked</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="415644" checksum="2">
+										<typ>FAST</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-08-14</handlingDatum>
+										<uuid>5e2b482f-b342-454c-be51-ab80beac050f</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="567085" checksum="1827264204">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Fastställd kontrollplan</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="362912" checksum="43">
+								<riktning>Ut</riktning>
+								<rubrik>Arkiveras i Formpipe</rubrik>
+								<startDatum>2020-09-22T09:55:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>FORMPIPE</handelseslag>
+								<handelsetyp>ARKIV</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="413207" checksum="55">
+										<typ>ANM</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-07-02</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="564552" checksum="-196680004">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Anmälan</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="415643" checksum="2">
+										<typ>STAB</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-08-14</handlingDatum>
+										<uuid>4b06e108-571b-4354-b300-f4bc0ad7ae80</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="567084" checksum="-188279055">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Startbesked</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="415644" checksum="2">
+										<typ>FAST</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-08-14</handlingDatum>
+										<uuid>5e2b482f-b342-454c-be51-ab80beac050f</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="567085" checksum="1827264204">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Fastställd kontrollplan</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="419505" checksum="37">
+										<typ>SKP</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2020-09-22</handlingDatum>
+										<uuid>5ae0c901-1684-41ad-a2db-a765bf3c3167</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="571053" checksum="821951314">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Signerad kontrollplan</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="maj27nym"/>
+							</handelse>
+							<handelse handelseId="362913" checksum="3">
+								<riktning>Ut</riktning>
+								<rubrik>Arkiveras i Formpipe</rubrik>
+								<startDatum>2021-12-15T09:26:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>FORMPIPE</handelseslag>
+								<handelsetyp>ARKIV</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="419506" checksum="41">
+										<typ>SBES</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2020-09-22</handlingDatum>
+										<uuid>72e9455e-147c-4960-a6d8-b47d86fa1af8</uuid>
+										<arkivStatus>Arkiveras</arkivStatus>
+										<makulerad>false</makulerad>
+										<dokument dokId="571054" checksum="-1342627291">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Slutbesked</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>true</arbetsmaterial>
+								<handlaggare signatur="maj27nym"/>
+							</handelse>
+							<handelse handelseId="344776" checksum="42">
+								<riktning>In</riktning>
+								<rubrik>Kompletterande handlingar</rubrik>
+								<startDatum>2020-08-13T13:20:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>KOMPL</handelseslag>
+								<handelsetyp>HANDLING</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="415497" checksum="56">
+										<typ>FAS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566936" checksum="-565850922">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="415498" checksum="30">
+										<typ>SEKT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566937" checksum="898288383">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="415499" checksum="30">
+										<typ>SEKT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566938" checksum="1642120141">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="415500" checksum="57">
+										<typ>PLA</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566939" checksum="880137261">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="sus11ost"/>
+							</handelse>
+							<handelse handelseId="344779" checksum="3">
+								<riktning>In</riktning>
+								<rubrik>Kompletterande handlingar</rubrik>
+								<startDatum>2020-08-13T13:34:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>KOMPL</handelseslag>
+								<handelsetyp>HANDLING</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="415501" checksum="57">
+										<typ>PRES</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566940" checksum="1475912738">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="sus11ost"/>
+							</handelse>
+							<handelse handelseId="344208" checksum="39">
+								<riktning>Okänd</riktning>
+								<rubrik>Beslut</rubrik>
+								<startDatum>2020-08-07T12:29:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>Beslut</handelseslag>
+								<handelsetyp>KOMP</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="414947" checksum="49">
+										<typ>KOMP</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2020-08-07</handlingDatum>
+										<uuid>dd1e8090-7eed-4f06-b3cd-d7a398020287</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="566369" checksum="491027443">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Kompletteringsföreläggande</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="sus11ost"/>
+							</handelse>
+							<handelse handelseId="348408" checksum="62">
+								<riktning>In</riktning>
+								<rubrik>Signerad kontrollplan</rubrik>
+								<startDatum>2020-09-22T09:52:00+02:00</startDatum>
+								<anteckning/>
+								<handelsetyp>HANDLING</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="419505" checksum="37">
+										<typ>SKP</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2020-09-22</handlingDatum>
+										<uuid>5ae0c901-1684-41ad-a2db-a765bf3c3167</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="571053" checksum="821951314">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Signerad kontrollplan</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+						</handelseLista>
+						<projektnr xmlns="www.tekis.se/arende">TEST 1:9</projektnr>
+						<objektLista xmlns="www.tekis.se/arende">
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="52508"
+												  arHuvudObjekt="true"
+												  checksum="1|">
+								<belAdressList>
+									<arendeBelagenhetAdress arendeObjektId="52508">
+										<belAdress>
+											<adressOmrade>TEST</adressOmrade>
+											<adressPlatsNr>130</adressPlatsNr>
+										</belAdress>
+									</arendeBelagenhetAdress>
+								</belAdressList>
+								<fastighet checksum="191337564|" fnr="22047085">
+									<trakt>TEST</trakt>
+									<fbetNr>3:31</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+						</objektLista>
+					</arende>
+					<arende arendeId="55523" dnr="BYGG 2021-000772" diarieprefix="BYGG"
+							kommun="Sundsvall" enhet="SBK"
+							enhetkod="" arendegrupp="LOV" arendetyp="BL" arendeslag="A"
+							arendeklass="ÅTER"
+							namndkod="SBN" kalla="3">
+						<status xmlns="www.tekis.se/arende">Pågående</status>
+						<beskrivning xmlns="www.tekis.se/arende">Bygglov för nybyggnad av
+							återvinningsstation &amp;
+							förråd
+						</beskrivning>
+						<ankomstDatum xmlns="www.tekis.se/arende">2021-12-16</ankomstDatum>
+						<uppdateradDatum xmlns="www.tekis.se/arende">2021-12-16</uppdateradDatum>
+						<registreradDatum xmlns="www.tekis.se/arende">2021-12-16</registreradDatum>
+						<handlaggare handlaggareId="-1" signatur="" xmlns="www.tekis.se/arende">
+							<fornamn/>
+							<efternamn/>
+						</handlaggare>
+						<intressentLista xmlns="www.tekis.se/arende">
+							<intressent intressentId="36533" attentionId="0"
+										intressentVersionId="56180">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress>Ett namn</coAdress>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land>Sverige</land>
+								<fornamn/>
+								<efternamn/>
+								<attention/>
+								<rollLista>
+									<roll>BETA</roll>
+									<roll>FAG</roll>
+									<roll>SOK</roll>
+								</rollLista>
+							</intressent>
+						</intressentLista>
+						<handelseLista xmlns="www.tekis.se/arende">
+							<handelse handelseId="362927" checksum="7">
+								<riktning>In</riktning>
+								<rubrik>Bygglov</rubrik>
+								<startDatum>2021-12-16T14:03:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>Bygglov</handelseslag>
+								<handelsetyp>ANSÖKAN</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="434992" checksum="6">
+										<typ>ANS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>Namn på dokumentet</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586457" checksum="-603027619">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="SYSTEM"/>
+							</handelse>
+							<handelse handelseId="362928" checksum="6">
+								<riktning>In</riktning>
+								<rubrik>Manuell hantering</rubrik>
+								<startDatum>2021-12-16T14:03:00+01:00</startDatum>
+								<anteckning>Det finns uppgifter om kontrollansvarig i handlingen
+									"Ansökan om bygglov".
+									Du måste registrera denna typ av intressenter manuellt.
+								</anteckning>
+								<handelseslag>MANHANT</handelseslag>
+								<handelsetyp>STATUS</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="SYSTEM"/>
+							</handelse>
+						</handelseLista>
+						<projektnr xmlns="www.tekis.se/arende">TEST 1:9</projektnr>
+						<objektLista xmlns="www.tekis.se/arende">
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="56361"
+												  arHuvudObjekt="false" checksum="0|">
+								<fastighet checksum="872748661|" fnr="22045607">
+									<trakt>TEST</trakt>
+									<fbetNr>36:14</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="56362"
+												  arHuvudObjekt="true"
+												  checksum="1|">
+								<fastighet checksum="-1426320077|" fnr="22047538">
+									<trakt>TEST</trakt>
+									<fbetNr>1:5</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+						</objektLista>
+					</arende>
+					<arende arendeId="51221" dnr="BYGG 2020-000602" diarieprefix="BYGG"
+							kommun="Sundsvall" enhet="SBK"
+							enhetkod="" arendegrupp="HISS" arendetyp="HISS" arendeslag="Tillsyn"
+							arendeklass=""
+							namndkod="SBN" kalla="1">
+						<status xmlns="www.tekis.se/arende">Pågående</status>
+						<beskrivning xmlns="www.tekis.se/arende">Hiss/port Tillsyn</beskrivning>
+						<ankomstDatum xmlns="www.tekis.se/arende">2020-05-20</ankomstDatum>
+						<slutDatum xmlns="www.tekis.se/arende">2020-09-16</slutDatum>
+						<uppdateradDatum xmlns="www.tekis.se/arende">2021-12-17</uppdateradDatum>
+						<registreradDatum xmlns="www.tekis.se/arende">2020-05-07</registreradDatum>
+						<handlaggare handlaggareId="1602" signatur="maj27nym"
+									 xmlns="www.tekis.se/arende">
+							<fornamn>Test</fornamn>
+							<fornamn>Testorsson</fornamn>
+						</handlaggare>
+						<intressentLista xmlns="www.tekis.se/arende">
+							<intressent intressentId="32593" attentionId="0"
+										intressentVersionId="48818">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn/>
+								<efternamn/>
+								<attention/>
+								<rollLista>
+									<roll>FAG</roll>
+								</rollLista>
+							</intressent>
+						</intressentLista>
+						<handelseLista xmlns="www.tekis.se/arende">
+							<handelse handelseId="333418" checksum="6">
+								<riktning>Okänd</riktning>
+								<rubrik>Åtgärdsföreläggande</rubrik>
+								<startDatum>2020-05-07T10:06:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>ÅTG</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="true">
+									<beslutstext/>
+									<delegatHandlaggare signatur="hel07sah">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="404098" checksum="49">
+										<typ>ÅTG</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-05-07</handlingDatum>
+										<uuid>d95329ba-1240-4673-91c0-dd77e3b298b6</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="555274" checksum="1959960674">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Åtgärdsföreläggande</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="343426" checksum="53">
+								<riktning>Okänd</riktning>
+								<rubrik>Åtgärdsföreläggande Påminnelse</rubrik>
+								<startDatum>2020-07-24T13:12:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>ÅTG1</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="false">
+									<beslutstext/>
+									<delegatHandlaggare signatur="mik23kal">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="414096" checksum="55">
+										<typ>ÅTG</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-07-24</handlingDatum>
+										<uuid>c7ca17e5-51ba-4e7c-a0ea-b88b6686c915</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="565459" checksum="-955246044">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Åtgärdsföreläggande</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="346646" checksum="57">
+								<riktning>In</riktning>
+								<rubrik>Hissityg med brist som inte utgör omedelbar betydelse för
+									säkerhet och hälsa
+									(Inkom 2020-09-03)
+								</rubrik>
+								<startDatum>2020-05-20T13:17:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>KOMPL</handelseslag>
+								<handelsetyp>HANDLING</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="417690" checksum="44">
+										<typ>HISSINT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-05-20</handlingDatum>
+										<anteckning>S407656, med brist som INTE utgör omedelbar
+											betydelse för säkerhet
+											och hälsa.
+										</anteckning>
+										<uuid>9d9526ea-6730-4ec6-bee3-09f716330f87</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="569175" checksum="1878325693">
+											<namn>SKIFU-2020-00019-3 Intyg ombesiktning Personhiss
+												Sköle
+												1003829_1_1.pdf
+											</namn>
+											<beskrivning>Hissintyg</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="333417" checksum="20">
+								<riktning>Okänd</riktning>
+								<rubrik>Tillsyn</rubrik>
+								<startDatum>2020-03-11T00:00:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>TILL</handelseslag>
+								<handelsetyp>ANM</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="404096" checksum="21">
+										<typ>HISSINT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-03-11</handlingDatum>
+										<anteckning>S407656</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="555272" checksum="-1741504962">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Hissintyg</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+						</handelseLista>
+						<projektnr xmlns="www.tekis.se/arende">TEST 1:9</projektnr>
+						<objektLista xmlns="www.tekis.se/arende">
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="51885"
+												  arHuvudObjekt="true"
+												  checksum="1|">
+								<belAdressList>
+									<arendeBelagenhetAdress arendeObjektId="51885">
+										<belAdress>
+											<adressOmrade>TEST</adressOmrade>
+											<adressPlatsNr>2</adressPlatsNr>
+										</belAdress>
+									</arendeBelagenhetAdress>
+								</belAdressList>
+								<fastighet checksum="2064711193|" fnr="22075202">
+									<trakt>TEST</trakt>
+									<fbetNr>1:81</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+						</objektLista>
+					</arende>
+					<arende arendeId="51234" dnr="BYGG 2020-000615" diarieprefix="BYGG"
+							kommun="Sundsvall" enhet="SBK"
+							enhetkod="" arendegrupp="HISS" arendetyp="HISS" arendeslag="Tillsyn"
+							arendeklass=""
+							namndkod="SBN" kalla="1">
+						<status xmlns="www.tekis.se/arende">Avslutat</status>
+						<beskrivning xmlns="www.tekis.se/arende">Hiss/port Tillsyn</beskrivning>
+						<ankomstDatum xmlns="www.tekis.se/arende">2020-03-11</ankomstDatum>
+						<slutDatum xmlns="www.tekis.se/arende">2020-07-02</slutDatum>
+						<uppdateradDatum xmlns="www.tekis.se/arende">2021-12-17</uppdateradDatum>
+						<registreradDatum xmlns="www.tekis.se/arende">2020-05-07</registreradDatum>
+						<handlaggare handlaggareId="822" signatur="hel07sah"
+									 xmlns="www.tekis.se/arende">
+							<fornamn>Test</fornamn>
+							<fornamn>Testorsson</fornamn>
+						</handlaggare>
+						<intressentLista xmlns="www.tekis.se/arende">
+							<intressent intressentId="28514" attentionId="0"
+										intressentVersionId="41520">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn/>
+								<efternamn/>
+								<attention/>
+								<rollLista>
+									<roll>FAG</roll>
+								</rollLista>
+							</intressent>
+						</intressentLista>
+						<handelseLista xmlns="www.tekis.se/arende">
+							<handelse handelseId="362929" checksum="9">
+								<riktning>Ut</riktning>
+								<rubrik>Arkiveras i Formpipe</rubrik>
+								<startDatum>2020-07-02T15:09:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>FORMPIPE</handelseslag>
+								<handelsetyp>ARKIV</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="maj27nym"/>
+							</handelse>
+							<handelse handelseId="333490" checksum="36">
+								<riktning>Okänd</riktning>
+								<rubrik>Åtgärdsföreläggande L0360859</rubrik>
+								<startDatum>2020-05-07T13:05:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>ÅTG</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="true">
+									<beslutstext/>
+									<delegatHandlaggare signatur="hel07sah">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="404186" checksum="13">
+										<typ>ÅTG</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-05-07</handlingDatum>
+										<anteckning>L0360859</anteckning>
+										<uuid>c02499eb-9ac3-447f-bba4-fb8793a93565</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="555363" checksum="-1067989268">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Åtgärdsföreläggande</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="333492" checksum="37">
+								<riktning>Okänd</riktning>
+								<rubrik>Åtgärdsföreläggande L0360842</rubrik>
+								<startDatum>2020-05-07T13:08:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>ÅTG</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="false">
+									<beslutstext/>
+									<delegatHandlaggare signatur="hel07sah">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="404188" checksum="34">
+										<typ>ÅTG</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-05-07</handlingDatum>
+										<anteckning>L0360842</anteckning>
+										<uuid>a0281162-c389-4e4a-ab14-264b5dab1fdb</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="555365" checksum="-1067989268">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Åtgärdsföreläggande</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="333489" checksum="25">
+								<riktning>Okänd</riktning>
+								<rubrik>Tillsyn</rubrik>
+								<startDatum>2020-03-11T00:00:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>TILL</handelseslag>
+								<handelsetyp>ANM</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="404184" checksum="11">
+										<typ>HISSINT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-03-11</handlingDatum>
+										<anteckning>L0360842</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="555361" checksum="-856731286">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Hissintyg</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="404185" checksum="26">
+										<typ>HISSINT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-03-11</handlingDatum>
+										<anteckning>L0360859</anteckning>
+										<uuid>6bce494d-8a59-4622-b8c3-7f7d422ff066</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="555362" checksum="-136794136">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Hissintyg</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="341457" checksum="34">
+								<riktning>In</riktning>
+								<rubrik>Godkända hissintyg</rubrik>
+								<startDatum>2020-07-02T13:00:00+02:00</startDatum>
+								<anteckning/>
+								<handelsetyp>HANDLING</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="412175" checksum="3">
+										<typ>HISSINT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-07-02</handlingDatum>
+										<anteckning>Godkänd, L0360859</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="563509" checksum="444883367">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="412176" checksum="2">
+										<typ>HISSINT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-07-02</handlingDatum>
+										<anteckning>Godkänd, L0360842</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="563510" checksum="-454090230">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+						</handelseLista>
+						<objektLista xmlns="www.tekis.se/arende">
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="51898"
+												  arHuvudObjekt="true"
+												  checksum="1|">
+								<belAdressList>
+									<arendeBelagenhetAdress arendeObjektId="51898">
+										<belAdress>
+											<adressOmrade>TEST</adressOmrade>
+											<adressPlatsNr>530</adressPlatsNr>
+										</belAdress>
+									</arendeBelagenhetAdress>
+								</belAdressList>
+								<fastighet checksum="-1069093451|" fnr="22041266">
+									<trakt>TEST</trakt>
+									<fbetNr>1:41</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+						</objektLista>
+					</arende>
+					<arende arendeId="42736" dnr="BYGG 2018-000026" diarieprefix="BYGG"
+							kommun="Sundsvall" enhet="SBK"
+							enhetkod="" arendegrupp="LOV" arendetyp="BL" arendeslag="A"
+							arendeklass="FRI" namndkod="SBN"
+							kalla="1">
+						<status xmlns="www.tekis.se/arende">Avslutat</status>
+						<beskrivning xmlns="www.tekis.se/arende">Bygglov Nybyggnad fritidshus
+							AVSKRIVET
+						</beskrivning>
+						<ankomstDatum xmlns="www.tekis.se/arende">2018-01-15</ankomstDatum>
+						<slutDatum xmlns="www.tekis.se/arende">2018-01-30</slutDatum>
+						<uppdateradDatum xmlns="www.tekis.se/arende">2021-12-17</uppdateradDatum>
+						<registreradDatum xmlns="www.tekis.se/arende">2018-01-15</registreradDatum>
+						<handlaggare handlaggareId="822" signatur="hel07sah"
+									 xmlns="www.tekis.se/arende">
+							<fornamn>Test</fornamn>
+							<fornamn>Testorsson</fornamn>
+						</handlaggare>
+						<intressentLista xmlns="www.tekis.se/arende">
+							<intressent intressentId="22231" attentionId="0"
+										intressentVersionId="29301">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn>Test</fornamn>
+								<fornamn>Testorsson</fornamn>
+								<attention/>
+								<rollLista>
+									<roll>FAG</roll>
+								</rollLista>
+							</intressent>
+							<intressent intressentId="22232" attentionId="0"
+										intressentVersionId="39187">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn>Test</fornamn>
+								<fornamn>Testorsson</fornamn>
+								<attention/>
+								<rollLista>
+									<roll>SOK</roll>
+								</rollLista>
+							</intressent>
+							<intressent intressentId="22230" attentionId="0"
+										intressentVersionId="29300">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn>Test</fornamn>
+								<fornamn>Testorsson</fornamn>
+								<attention/>
+								<rollLista>
+									<roll>FAG</roll>
+								</rollLista>
+							</intressent>
+						</intressentLista>
+						<handelseLista xmlns="www.tekis.se/arende">
+							<handelse handelseId="276911" checksum="25">
+								<riktning>In</riktning>
+								<rubrik>Bygglov</rubrik>
+								<startDatum>2018-01-15T08:51:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>Bygglov</handelseslag>
+								<handelsetyp>ANSÖKAN</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="328921" checksum="62">
+										<typ>ANS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431169" checksum="-427559378">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Ansökan om bygglov</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="328922" checksum="46">
+										<typ>FAPL</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431174" checksum="-507595760">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Fasad plan sektion</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="328923" checksum="12">
+										<typ>FPSS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431173" checksum="1955768040">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Fasad plan sektion situationsplan
+											</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="328924" checksum="49">
+										<typ>UKON</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431175" checksum="-1965431634">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Konstruktionshandlingar</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="328925" checksum="14">
+										<typ>SEKT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431171" checksum="14858542">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Sektioner</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="328926" checksum="30">
+										<typ>SITU</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431170" checksum="2076100622">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Situationsplan</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="328928" checksum="36">
+										<typ>FÖLJ</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<anteckning>Ärendeblad</anteckning>
+										<uuid>72cfb195-0b91-42b1-bb22-1f971c91f816</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="431176" checksum="233089522">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Följebrev</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="277833" checksum="54">
+								<riktning>Okänd</riktning>
+								<rubrik>Avskrivning, Avslutas</rubrik>
+								<startDatum>2018-01-30T12:23:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>UAB</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<handelseutfall>AVSL</handelseutfall>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="true">
+									<beslutstext/>
+									<delegatHandlaggare signatur="ann31jer">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgSTA</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="330161" checksum="52">
+										<typ>@BESLUT</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2018-01-30</handlingDatum>
+										<uuid>5415483d-007a-4ef6-93c2-8e59caab09e5</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="433467" checksum="-1465822860">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Beslut</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>true</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="362930" checksum="0">
+								<riktning>Ut</riktning>
+								<rubrik>Arkiveras i Formpipe</rubrik>
+								<startDatum>2018-01-30T15:14:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>FORMPIPE</handelseslag>
+								<handelsetyp>ARKIV</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="328921" checksum="62">
+										<typ>ANS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431169" checksum="-427559378">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Ansökan om bygglov</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="330161" checksum="52">
+										<typ>@BESLUT</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2018-01-30</handlingDatum>
+										<uuid>5415483d-007a-4ef6-93c2-8e59caab09e5</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="433467" checksum="-1465822860">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Beslut</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="maj27nym"/>
+							</handelse>
+							<handelse handelseId="277834" checksum="57">
+								<riktning>Ut</riktning>
+								<rubrik>Skrivelse från sökande</rubrik>
+								<startDatum>2018-01-23T12:31:00+01:00</startDatum>
+								<anteckning/>
+								<handelsetyp>HANDLING</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="330162" checksum="5">
+										<typ>SKR</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-23</handlingDatum>
+										<uuid>8d0eb5cf-79a1-416f-a9db-feed99d7b26c</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="433468" checksum="1840526893">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Skrivelse</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>true</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+						</handelseLista>
+						<objektLista xmlns="www.tekis.se/arende">
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="43397"
+												  arHuvudObjekt="true"
+												  checksum="1|">
+								<fastighet checksum="1294563468|" fnr="22047495">
+									<trakt>TEST</trakt>
+									<fbetNr>3:6</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+						</objektLista>
+					</arende>
+				</Arenden>
+			</GetUpdatedArendenResult>
+		</GetUpdatedArendenResponse>
+	</s:Body>
+</s:Envelope>

--- a/src/integration-test/resources/IntegrationTest/__files/test15_byggrFetchError/mappings/arendeexport.GetDocument.500.json
+++ b/src/integration-test/resources/IntegrationTest/__files/test15_byggrFetchError/mappings/arendeexport.GetDocument.500.json
@@ -1,0 +1,26 @@
+{
+	"priority": 1,
+	"request": {
+		"method": "POST",
+		"url": "/TekisArende/ArendeExportWS.svc",
+		"bodyPatterns": [
+			{
+				"and": [
+					{
+						"contains": "GetDocument"
+					},
+					{
+						"contains": "433467"
+					}
+				]
+			}
+		]
+	},
+	"response": {
+		"headers": {
+			"Content-Type": "text/xml; charset=utf-8"
+		},
+		"bodyFileName": "test15_byggrFetchError/response/arendeexport.GetDocument.500.xml",
+		"status": 500
+	}
+}

--- a/src/integration-test/resources/IntegrationTest/__files/test15_byggrFetchError/mappings/arendeexport.GetUpdatedArenden.200.json
+++ b/src/integration-test/resources/IntegrationTest/__files/test15_byggrFetchError/mappings/arendeexport.GetUpdatedArenden.200.json
@@ -1,0 +1,27 @@
+{
+	"priority": 1,
+	"request": {
+		"method": "POST",
+		"url": "/TekisArende/ArendeExportWS.svc",
+		"bodyPatterns": [
+			{
+				"and": [
+					{
+						"contains": "GetUpdatedArenden"
+					},
+					{
+						"contains": "UpperInclusiveBound>2021-12-17T23:59:59"
+					}
+				]
+			}
+		]
+	},
+	"response": {
+		"headers": {
+			"Server": "Microsoft-IIS/10.0",
+			"Content-Type": "text/xml; charset=utf-8"
+		},
+		"bodyFileName": "test14_failingBatch/response/arendeexport.GetUpdatedArenden.200.xml",
+		"status": 200
+	}
+}

--- a/src/integration-test/resources/IntegrationTest/__files/test15_byggrFetchError/response/arendeexport.GetDocument.500.xml
+++ b/src/integration-test/resources/IntegrationTest/__files/test15_byggrFetchError/response/arendeexport.GetDocument.500.xml
@@ -1,0 +1,17 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+	<s:Body>
+		<s:Fault>
+			<faultcode
+					xmlns:a="http://schemas.microsoft.com/net/2005/12/windowscommunicationfoundation/dispatcher">
+				a:InternalServiceFault
+			</faultcode>
+			<faultstring xml:lang="sv-SE">The server was unable to process the request due to an
+				internal error. For more information about the error, either turn on
+				IncludeExceptionDetailInFaults (either from ServiceBehaviorAttribute or from the
+				&lt;serviceDebug> configuration behavior) on the server in order to send the
+				exception information back to the client, or turn on tracing as per the Microsoft
+				.NET Framework SDK documentation and inspect the server trace logs.
+			</faultstring>
+		</s:Fault>
+	</s:Body>
+</s:Envelope>

--- a/src/integration-test/resources/IntegrationTest/__files/test15_byggrFetchError/response/arendeexport.GetUpdatedArenden.200.xml
+++ b/src/integration-test/resources/IntegrationTest/__files/test15_byggrFetchError/response/arendeexport.GetUpdatedArenden.200.xml
@@ -1,0 +1,1561 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+	<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	>
+		<GetUpdatedArendenResponse xmlns="www.tekis.se/ServiceContract">
+			<GetUpdatedArendenResult>
+				<BatchStart>2021-12-17T00:00:00</BatchStart>
+				<BatchEnd>2021-12-17T23:59:59</BatchEnd>
+				<Arenden>
+					<arende arendeId="55522" dnr="BYGG 2021-000771" diarieprefix="BYGG"
+							kommun="Sundsvall" enhet="SBK"
+							enhetkod="" arendegrupp="LOV" arendetyp="BL" arendeslag="A"
+							arendeklass="LB" namndkod="SBN"
+							kalla="3">
+						<status xmlns="www.tekis.se/arende">Pågående</status>
+						<beskrivning xmlns="www.tekis.se/arende">Bygglov för nybyggnad av
+							lagerbyggnad, parkering &amp;
+							småbåtshamn
+						</beskrivning>
+						<ankomstDatum xmlns="www.tekis.se/arende">2021-12-16</ankomstDatum>
+						<uppdateradDatum xmlns="www.tekis.se/arende">2021-12-16</uppdateradDatum>
+						<registreradDatum xmlns="www.tekis.se/arende">2021-12-16</registreradDatum>
+						<handlaggare handlaggareId="-1" signatur="" xmlns="www.tekis.se/arende">
+							<fornamn/>
+							<efternamn/>
+						</handlaggare>
+						<intressentLista xmlns="www.tekis.se/arende">
+							<intressent intressentId="36552" attentionId="11858"
+										arForetag="true" intressentVersionId="56522">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress>co adress</coAdress>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn/>
+								<efternamn/>
+								<attention>attention</attention>
+								<rollLista>
+									<roll>SOK</roll>
+								</rollLista>
+							</intressent>
+							<intressent intressentId="36540" attentionId="0"
+										intressentVersionId="56524">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress>annan kontakt co</coAdress>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn/>
+								<efternamn/>
+								<attention/>
+								<rollLista>
+									<roll>BETA</roll>
+								</rollLista>
+							</intressent>
+							<intressent intressentId="36535" attentionId="0"
+										intressentVersionId="56523">
+								<namn>Test Testorsson</namn>
+								<adress/>
+								<coAdress/>
+								<postNr/>
+								<ort/>
+								<land/>
+								<fornamn/>
+								<efternamn/>
+								<attention/>
+								<rollLista>
+									<roll>KPER</roll>
+								</rollLista>
+							</intressent>
+						</intressentLista>
+						<handelseLista xmlns="www.tekis.se/arende">
+							<handelse handelseId="362923" checksum="60">
+								<riktning>In</riktning>
+								<rubrik>Bygglov</rubrik>
+								<startDatum>2021-12-16T08:16:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>Bygglov</handelseslag>
+								<handelsetyp>ANSÖKAN</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="434978" checksum="60">
+										<typ>ANS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>8902.pdf</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586443" checksum="-1243540383">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434979" checksum="60">
+										<typ>SITU</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>situationsplan Ritning1.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586444" checksum="-1933202738">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434980" checksum="61">
+										<typ>SEK2</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>sektionsritning Ritning3.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586445" checksum="1718795407">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434981" checksum="61">
+										<typ>RITNING</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>ritning Ritning3.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586446" checksum="-1268635663">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434982" checksum="61">
+										<typ>PLA2</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>planritning Ritning2.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586447" checksum="-1189009869">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434983" checksum="61">
+										<typ>NYKA</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>nybyggnadskarta Ritning1.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586448" checksum="-908427253">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434984" checksum="62">
+										<typ>FÖRK</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>kontrollplan Kontrollplan.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586449" checksum="702710784">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434985" checksum="62">
+										<typ>UKON</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>konstruktionsritning Ritning2.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586450" checksum="1772255952">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434986" checksum="62">
+										<typ>UKON</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>konstruktionshandling Ritning1.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586451" checksum="2070134623">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434987" checksum="62">
+										<typ>UKON</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>konstruktionshandling Fullmakt.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586452" checksum="-1379204737">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434988" checksum="62">
+										<typ>ANMÄ</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>kauppgifter KA uppgifter.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586453" checksum="-59093652">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434989" checksum="63">
+										<typ>FUM</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>fullmakt Fullmakt.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586454" checksum="-485473024">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434990" checksum="63">
+										<typ>FAS2</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>fasadritning Fasad väst.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586455" checksum="677502436">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="434991" checksum="63">
+										<typ>FAS2</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>fasadritning Fasad ost.docx</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586456" checksum="-77536153">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="SYSTEM"/>
+							</handelse>
+							<handelse handelseId="362924" checksum="63">
+								<riktning>In</riktning>
+								<rubrik>Manuell hantering</rubrik>
+								<startDatum>2021-12-16T08:16:00+01:00</startDatum>
+								<anteckning>Det finns uppgifter om kontrollansvarig i handlingen
+									"Ansökan om bygglov".
+									Du måste registrera denna typ av intressenter manuellt.
+								</anteckning>
+								<handelseslag>MANHANT</handelseslag>
+								<handelsetyp>STATUS</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="SYSTEM"/>
+							</handelse>
+						</handelseLista>
+						<projektnr xmlns="www.tekis.se/arende">TEST 1:9</projektnr>
+						<objektLista xmlns="www.tekis.se/arende">
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="56360"
+												  arHuvudObjekt="true"
+												  checksum="1|">
+								<fastighet checksum="-137380678|" fnr="22044360">
+									<trakt>TEST</trakt>
+									<fbetNr>1:9</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+						</objektLista>
+					</arende>
+					<arende arendeId="51828" dnr="BYGG 2020-001012" diarieprefix="BYGG"
+							kommun="Sundsvall" enhet="SBK"
+							enhetkod="" arendegrupp="LOV" arendetyp="ANM" arendeslag="C"
+							arendeklass="EB" namndkod="SBN"
+							kalla="1">
+						<status xmlns="www.tekis.se/arende">Pågående</status>
+						<beskrivning xmlns="www.tekis.se/arende">Anmälan för installation av eldstad
+							och rökkanal
+							enbostadshus
+						</beskrivning>
+						<ankomstDatum xmlns="www.tekis.se/arende">2020-07-02</ankomstDatum>
+						<uppdateradDatum xmlns="www.tekis.se/arende">2021-12-16</uppdateradDatum>
+						<registreradDatum xmlns="www.tekis.se/arende">2020-07-10</registreradDatum>
+						<handlaggare handlaggareId="1602" signatur="maj27nym"
+									 xmlns="www.tekis.se/arende">
+							<fornamn>Test</fornamn>
+							<fornamn>Testorsson</fornamn>
+						</handlaggare>
+						<intressentLista xmlns="www.tekis.se/arende">
+							<intressent intressentId="27055" attentionId="10277"
+										arForetag="true" intressentVersionId="38853">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn/>
+								<efternamn/>
+								<attention>Kontakt</attention>
+								<rollLista>
+									<roll>KPER</roll>
+								</rollLista>
+							</intressent>
+							<intressent intressentId="14743" attentionId="0"
+										intressentVersionId="53487">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn>Test</fornamn>
+								<fornamn>Testorsson</fornamn>
+								<attention/>
+								<rollLista>
+									<roll>FAG</roll>
+									<roll>SOK</roll>
+								</rollLista>
+							</intressent>
+						</intressentLista>
+						<handelseLista xmlns="www.tekis.se/arende">
+							<handelse handelseId="344948" checksum="15">
+								<riktning>Okänd</riktning>
+								<rubrik>Fastställd kontrollplan</rubrik>
+								<startDatum>2020-08-14T11:29:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>GBCA</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="false">
+									<beslutstext/>
+									<delegatHandlaggare signatur="hel07sah">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="415644" checksum="2">
+										<typ>FAST</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-08-14</handlingDatum>
+										<uuid>5e2b482f-b342-454c-be51-ab80beac050f</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="567085" checksum="1827264204">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Fastställd kontrollplan</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="344780" checksum="36">
+								<riktning>Ut</riktning>
+								<rubrik>Ärende komplett</rubrik>
+								<startDatum>2020-08-13T13:34:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>Komplett</handelseslag>
+								<handelsetyp>STATUS</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="sus11ost"/>
+							</handelse>
+							<handelse handelseId="344946" checksum="45">
+								<riktning>Okänd</riktning>
+								<rubrik>Startbesked</rubrik>
+								<startDatum>2020-08-14T11:23:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>GAAC</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut beslutNr="IN 2020-000833" arHuvudbeslut="true">
+									<beslutstext/>
+									<delegatHandlaggare signatur="hel07sah">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="413207" checksum="55">
+										<typ>ANM</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-07-02</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="564552" checksum="-196680004">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Anmälan</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="415497" checksum="56">
+										<typ>FAS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566936" checksum="-565850922">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="415500" checksum="57">
+										<typ>PLA</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566939" checksum="880137261">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="415501" checksum="57">
+										<typ>PRES</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566940" checksum="1475912738">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="415643" checksum="2">
+										<typ>STAB</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-08-14</handlingDatum>
+										<uuid>4b06e108-571b-4354-b300-f4bc0ad7ae80</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="567084" checksum="-188279055">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Startbesked</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="sus11ost"/>
+							</handelse>
+							<handelse handelseId="348409" checksum="41">
+								<riktning>Ut</riktning>
+								<rubrik>Slutbesked</rubrik>
+								<startDatum>2020-09-22T09:54:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>SLU</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="false">
+									<beslutstext/>
+									<delegatHandlaggare signatur="mik23kal">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="419506" checksum="41">
+										<typ>SBES</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2020-09-22</handlingDatum>
+										<uuid>72e9455e-147c-4960-a6d8-b47d86fa1af8</uuid>
+										<arkivStatus>Arkiveras</arkivStatus>
+										<makulerad>false</makulerad>
+										<dokument dokId="571054" checksum="-1342627291">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Slutbesked</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="342498" checksum="41">
+								<riktning>In</riktning>
+								<rubrik>Eldstad/Rökkanal</rubrik>
+								<startDatum>2020-07-02T00:00:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>ELD</handelseslag>
+								<handelsetyp>ANM</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="413207" checksum="55">
+										<typ>ANM</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-07-02</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="564552" checksum="-196680004">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Anmälan</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="sus11ost"/>
+							</handelse>
+							<handelse handelseId="342542" checksum="50">
+								<riktning>Okänd</riktning>
+								<rubrik>Bekräftelse skickad</rubrik>
+								<startDatum>2020-07-10T17:03:00+02:00</startDatum>
+								<anteckning>Mottagargrupp:
+									Kontakt:
+									Skickade e-post till info@eldstaden.com - Utskick Kontakt 1.eml
+
+									Olof Näsman:
+									Skickade e-post till ollenasman@yahoo.se - Utskick Olof Näsman
+									1.eml
+
+
+								</anteckning>
+								<handelseslag>Kv</handelseslag>
+								<handelsetyp>Atom</handelsetyp>
+								<handelseutfall>Kv4</handelseutfall>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>true</arbetsmaterial>
+								<handlaggare signatur="Atom"/>
+							</handelse>
+							<handelse handelseId="344254" checksum="8">
+								<riktning>Okänd</riktning>
+								<rubrik>Kompletteringsföreläggande - skickat</rubrik>
+								<startDatum>2020-08-07T17:07:00+02:00</startDatum>
+								<anteckning>Mottagargrupp:
+									Kontakt:
+									Skickade e-post till info@eldstaden.com - Utskick Kontakt 1.eml
+
+									Olof Näsman:
+									Skickade e-post till ollenasman@yahoo.se - Utskick Olof Näsman
+									1.eml
+
+
+									Ärendebevakning SvarKompl skapades för ärende BYGG 2020-001012
+									kopplad till
+									handläggare Atom
+								</anteckning>
+								<handelseslag>Kv</handelseslag>
+								<handelsetyp>Atom</handelsetyp>
+								<handelseutfall>Kv11</handelseutfall>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>true</arbetsmaterial>
+								<handlaggare signatur="Atom"/>
+							</handelse>
+							<handelse handelseId="344950" checksum="47">
+								<riktning>Ut</riktning>
+								<rubrik>Anmälan</rubrik>
+								<startDatum>2020-08-14T11:31:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>ANM</handelseslag>
+								<handelsetyp>DEBIT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="344951" checksum="12">
+								<riktning>Ut</riktning>
+								<rubrik>Digitalt utskick av beslut</rubrik>
+								<startDatum>2020-08-14T11:31:00+02:00</startDatum>
+								<anteckning>Hej,
+
+									Här kommer ditt beslut.
+
+									Med vänlig hälsning
+
+									Sundsvalls Kommun
+									Stadsbyggnadskontoret
+									Bygglovavdelningen
+								</anteckning>
+								<handelseslag>DIGI</handelseslag>
+								<handelsetyp>DIG</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="415643" checksum="2">
+										<typ>STAB</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-08-14</handlingDatum>
+										<uuid>4b06e108-571b-4354-b300-f4bc0ad7ae80</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="567084" checksum="-188279055">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Startbesked</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="415644" checksum="2">
+										<typ>FAST</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-08-14</handlingDatum>
+										<uuid>5e2b482f-b342-454c-be51-ab80beac050f</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="567085" checksum="1827264204">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Fastställd kontrollplan</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="362912" checksum="43">
+								<riktning>Ut</riktning>
+								<rubrik>Arkiveras i Formpipe</rubrik>
+								<startDatum>2020-09-22T09:55:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>FORMPIPE</handelseslag>
+								<handelsetyp>ARKIV</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="413207" checksum="55">
+										<typ>ANM</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-07-02</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="564552" checksum="-196680004">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Anmälan</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="415643" checksum="2">
+										<typ>STAB</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-08-14</handlingDatum>
+										<uuid>4b06e108-571b-4354-b300-f4bc0ad7ae80</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="567084" checksum="-188279055">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Startbesked</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="415644" checksum="2">
+										<typ>FAST</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-08-14</handlingDatum>
+										<uuid>5e2b482f-b342-454c-be51-ab80beac050f</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="567085" checksum="1827264204">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Fastställd kontrollplan</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="419505" checksum="37">
+										<typ>SKP</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2020-09-22</handlingDatum>
+										<uuid>5ae0c901-1684-41ad-a2db-a765bf3c3167</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="571053" checksum="821951314">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Signerad kontrollplan</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="maj27nym"/>
+							</handelse>
+							<handelse handelseId="362913" checksum="3">
+								<riktning>Ut</riktning>
+								<rubrik>Arkiveras i Formpipe</rubrik>
+								<startDatum>2021-12-15T09:26:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>FORMPIPE</handelseslag>
+								<handelsetyp>ARKIV</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="419506" checksum="41">
+										<typ>SBES</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2020-09-22</handlingDatum>
+										<uuid>72e9455e-147c-4960-a6d8-b47d86fa1af8</uuid>
+										<arkivStatus>Arkiveras</arkivStatus>
+										<makulerad>false</makulerad>
+										<dokument dokId="571054" checksum="-1342627291">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Slutbesked</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>true</arbetsmaterial>
+								<handlaggare signatur="maj27nym"/>
+							</handelse>
+							<handelse handelseId="344776" checksum="42">
+								<riktning>In</riktning>
+								<rubrik>Kompletterande handlingar</rubrik>
+								<startDatum>2020-08-13T13:20:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>KOMPL</handelseslag>
+								<handelsetyp>HANDLING</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="415497" checksum="56">
+										<typ>FAS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566936" checksum="-565850922">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="415498" checksum="30">
+										<typ>SEKT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566937" checksum="898288383">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="415499" checksum="30">
+										<typ>SEKT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566938" checksum="1642120141">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="415500" checksum="57">
+										<typ>PLA</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566939" checksum="880137261">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="sus11ost"/>
+							</handelse>
+							<handelse handelseId="344779" checksum="3">
+								<riktning>In</riktning>
+								<rubrik>Kompletterande handlingar</rubrik>
+								<startDatum>2020-08-13T13:34:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>KOMPL</handelseslag>
+								<handelsetyp>HANDLING</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="415501" checksum="57">
+										<typ>PRES</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-08-13</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="566940" checksum="1475912738">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="sus11ost"/>
+							</handelse>
+							<handelse handelseId="344208" checksum="39">
+								<riktning>Okänd</riktning>
+								<rubrik>Beslut</rubrik>
+								<startDatum>2020-08-07T12:29:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>Beslut</handelseslag>
+								<handelsetyp>KOMP</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="414947" checksum="49">
+										<typ>KOMP</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2020-08-07</handlingDatum>
+										<uuid>dd1e8090-7eed-4f06-b3cd-d7a398020287</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="566369" checksum="491027443">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Kompletteringsföreläggande</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="sus11ost"/>
+							</handelse>
+							<handelse handelseId="348408" checksum="62">
+								<riktning>In</riktning>
+								<rubrik>Signerad kontrollplan</rubrik>
+								<startDatum>2020-09-22T09:52:00+02:00</startDatum>
+								<anteckning/>
+								<handelsetyp>HANDLING</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="419505" checksum="37">
+										<typ>SKP</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2020-09-22</handlingDatum>
+										<uuid>5ae0c901-1684-41ad-a2db-a765bf3c3167</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="571053" checksum="821951314">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Signerad kontrollplan</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+						</handelseLista>
+						<projektnr xmlns="www.tekis.se/arende">TEST 1:9</projektnr>
+						<objektLista xmlns="www.tekis.se/arende">
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="52508"
+												  arHuvudObjekt="true"
+												  checksum="1|">
+								<belAdressList>
+									<arendeBelagenhetAdress arendeObjektId="52508">
+										<belAdress>
+											<adressOmrade>TEST</adressOmrade>
+											<adressPlatsNr>130</adressPlatsNr>
+										</belAdress>
+									</arendeBelagenhetAdress>
+								</belAdressList>
+								<fastighet checksum="191337564|" fnr="22047085">
+									<trakt>TEST</trakt>
+									<fbetNr>3:31</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+						</objektLista>
+					</arende>
+					<arende arendeId="55523" dnr="BYGG 2021-000772" diarieprefix="BYGG"
+							kommun="Sundsvall" enhet="SBK"
+							enhetkod="" arendegrupp="LOV" arendetyp="BL" arendeslag="A"
+							arendeklass="ÅTER"
+							namndkod="SBN" kalla="3">
+						<status xmlns="www.tekis.se/arende">Pågående</status>
+						<beskrivning xmlns="www.tekis.se/arende">Bygglov för nybyggnad av
+							återvinningsstation &amp;
+							förråd
+						</beskrivning>
+						<ankomstDatum xmlns="www.tekis.se/arende">2021-12-16</ankomstDatum>
+						<uppdateradDatum xmlns="www.tekis.se/arende">2021-12-16</uppdateradDatum>
+						<registreradDatum xmlns="www.tekis.se/arende">2021-12-16</registreradDatum>
+						<handlaggare handlaggareId="-1" signatur="" xmlns="www.tekis.se/arende">
+							<fornamn/>
+							<efternamn/>
+						</handlaggare>
+						<intressentLista xmlns="www.tekis.se/arende">
+							<intressent intressentId="36533" attentionId="0"
+										intressentVersionId="56180">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress>Ett namn</coAdress>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land>Sverige</land>
+								<fornamn/>
+								<efternamn/>
+								<attention/>
+								<rollLista>
+									<roll>BETA</roll>
+									<roll>FAG</roll>
+									<roll>SOK</roll>
+								</rollLista>
+							</intressent>
+						</intressentLista>
+						<handelseLista xmlns="www.tekis.se/arende">
+							<handelse handelseId="362927" checksum="7">
+								<riktning>In</riktning>
+								<rubrik>Bygglov</rubrik>
+								<startDatum>2021-12-16T14:03:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>Bygglov</handelseslag>
+								<handelsetyp>ANSÖKAN</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="434992" checksum="6">
+										<typ>ANS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2021-12-16</handlingDatum>
+										<anteckning>Namn på dokumentet</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="586457" checksum="-603027619">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="SYSTEM"/>
+							</handelse>
+							<handelse handelseId="362928" checksum="6">
+								<riktning>In</riktning>
+								<rubrik>Manuell hantering</rubrik>
+								<startDatum>2021-12-16T14:03:00+01:00</startDatum>
+								<anteckning>Det finns uppgifter om kontrollansvarig i handlingen
+									"Ansökan om bygglov".
+									Du måste registrera denna typ av intressenter manuellt.
+								</anteckning>
+								<handelseslag>MANHANT</handelseslag>
+								<handelsetyp>STATUS</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="SYSTEM"/>
+							</handelse>
+						</handelseLista>
+						<projektnr xmlns="www.tekis.se/arende">TEST 1:9</projektnr>
+						<objektLista xmlns="www.tekis.se/arende">
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="56361"
+												  arHuvudObjekt="false" checksum="0|">
+								<fastighet checksum="872748661|" fnr="22045607">
+									<trakt>TEST</trakt>
+									<fbetNr>36:14</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="56362"
+												  arHuvudObjekt="true"
+												  checksum="1|">
+								<fastighet checksum="-1426320077|" fnr="22047538">
+									<trakt>TEST</trakt>
+									<fbetNr>1:5</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+						</objektLista>
+					</arende>
+					<arende arendeId="51221" dnr="BYGG 2020-000602" diarieprefix="BYGG"
+							kommun="Sundsvall" enhet="SBK"
+							enhetkod="" arendegrupp="HISS" arendetyp="HISS" arendeslag="Tillsyn"
+							arendeklass=""
+							namndkod="SBN" kalla="1">
+						<status xmlns="www.tekis.se/arende">Pågående</status>
+						<beskrivning xmlns="www.tekis.se/arende">Hiss/port Tillsyn</beskrivning>
+						<ankomstDatum xmlns="www.tekis.se/arende">2020-05-20</ankomstDatum>
+						<slutDatum xmlns="www.tekis.se/arende">2020-09-16</slutDatum>
+						<uppdateradDatum xmlns="www.tekis.se/arende">2021-12-17</uppdateradDatum>
+						<registreradDatum xmlns="www.tekis.se/arende">2020-05-07</registreradDatum>
+						<handlaggare handlaggareId="1602" signatur="maj27nym"
+									 xmlns="www.tekis.se/arende">
+							<fornamn>Test</fornamn>
+							<fornamn>Testorsson</fornamn>
+						</handlaggare>
+						<intressentLista xmlns="www.tekis.se/arende">
+							<intressent intressentId="32593" attentionId="0"
+										intressentVersionId="48818">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn/>
+								<efternamn/>
+								<attention/>
+								<rollLista>
+									<roll>FAG</roll>
+								</rollLista>
+							</intressent>
+						</intressentLista>
+						<handelseLista xmlns="www.tekis.se/arende">
+							<handelse handelseId="333418" checksum="6">
+								<riktning>Okänd</riktning>
+								<rubrik>Åtgärdsföreläggande</rubrik>
+								<startDatum>2020-05-07T10:06:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>ÅTG</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="true">
+									<beslutstext/>
+									<delegatHandlaggare signatur="hel07sah">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="404098" checksum="49">
+										<typ>ÅTG</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-05-07</handlingDatum>
+										<uuid>d95329ba-1240-4673-91c0-dd77e3b298b6</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="555274" checksum="1959960674">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Åtgärdsföreläggande</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="343426" checksum="53">
+								<riktning>Okänd</riktning>
+								<rubrik>Åtgärdsföreläggande Påminnelse</rubrik>
+								<startDatum>2020-07-24T13:12:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>ÅTG1</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="false">
+									<beslutstext/>
+									<delegatHandlaggare signatur="mik23kal">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="414096" checksum="55">
+										<typ>ÅTG</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-07-24</handlingDatum>
+										<uuid>c7ca17e5-51ba-4e7c-a0ea-b88b6686c915</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="565459" checksum="-955246044">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Åtgärdsföreläggande</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="346646" checksum="57">
+								<riktning>In</riktning>
+								<rubrik>Hissityg med brist som inte utgör omedelbar betydelse för
+									säkerhet och hälsa
+									(Inkom 2020-09-03)
+								</rubrik>
+								<startDatum>2020-05-20T13:17:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>KOMPL</handelseslag>
+								<handelsetyp>HANDLING</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="417690" checksum="44">
+										<typ>HISSINT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-05-20</handlingDatum>
+										<anteckning>S407656, med brist som INTE utgör omedelbar
+											betydelse för säkerhet
+											och hälsa.
+										</anteckning>
+										<uuid>9d9526ea-6730-4ec6-bee3-09f716330f87</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="569175" checksum="1878325693">
+											<namn>SKIFU-2020-00019-3 Intyg ombesiktning Personhiss
+												Sköle
+												1003829_1_1.pdf
+											</namn>
+											<beskrivning>Hissintyg</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="333417" checksum="20">
+								<riktning>Okänd</riktning>
+								<rubrik>Tillsyn</rubrik>
+								<startDatum>2020-03-11T00:00:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>TILL</handelseslag>
+								<handelsetyp>ANM</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="404096" checksum="21">
+										<typ>HISSINT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-03-11</handlingDatum>
+										<anteckning>S407656</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="555272" checksum="-1741504962">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Hissintyg</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+						</handelseLista>
+						<projektnr xmlns="www.tekis.se/arende">TEST 1:9</projektnr>
+						<objektLista xmlns="www.tekis.se/arende">
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="51885"
+												  arHuvudObjekt="true"
+												  checksum="1|">
+								<belAdressList>
+									<arendeBelagenhetAdress arendeObjektId="51885">
+										<belAdress>
+											<adressOmrade>TEST</adressOmrade>
+											<adressPlatsNr>2</adressPlatsNr>
+										</belAdress>
+									</arendeBelagenhetAdress>
+								</belAdressList>
+								<fastighet checksum="2064711193|" fnr="22075202">
+									<trakt>TEST</trakt>
+									<fbetNr>1:81</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+						</objektLista>
+					</arende>
+					<arende arendeId="51234" dnr="BYGG 2020-000615" diarieprefix="BYGG"
+							kommun="Sundsvall" enhet="SBK"
+							enhetkod="" arendegrupp="HISS" arendetyp="HISS" arendeslag="Tillsyn"
+							arendeklass=""
+							namndkod="SBN" kalla="1">
+						<status xmlns="www.tekis.se/arende">Avslutat</status>
+						<beskrivning xmlns="www.tekis.se/arende">Hiss/port Tillsyn</beskrivning>
+						<ankomstDatum xmlns="www.tekis.se/arende">2020-03-11</ankomstDatum>
+						<slutDatum xmlns="www.tekis.se/arende">2020-07-02</slutDatum>
+						<uppdateradDatum xmlns="www.tekis.se/arende">2021-12-17</uppdateradDatum>
+						<registreradDatum xmlns="www.tekis.se/arende">2020-05-07</registreradDatum>
+						<handlaggare handlaggareId="822" signatur="hel07sah"
+									 xmlns="www.tekis.se/arende">
+							<fornamn>Test</fornamn>
+							<fornamn>Testorsson</fornamn>
+						</handlaggare>
+						<intressentLista xmlns="www.tekis.se/arende">
+							<intressent intressentId="28514" attentionId="0"
+										intressentVersionId="41520">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn/>
+								<efternamn/>
+								<attention/>
+								<rollLista>
+									<roll>FAG</roll>
+								</rollLista>
+							</intressent>
+						</intressentLista>
+						<handelseLista xmlns="www.tekis.se/arende">
+							<handelse handelseId="362929" checksum="9">
+								<riktning>Ut</riktning>
+								<rubrik>Arkiveras i Formpipe</rubrik>
+								<startDatum>2020-07-02T15:09:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>FORMPIPE</handelseslag>
+								<handelsetyp>ARKIV</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista/>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="maj27nym"/>
+							</handelse>
+							<handelse handelseId="333490" checksum="36">
+								<riktning>Okänd</riktning>
+								<rubrik>Åtgärdsföreläggande L0360859</rubrik>
+								<startDatum>2020-05-07T13:05:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>ÅTG</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="true">
+									<beslutstext/>
+									<delegatHandlaggare signatur="hel07sah">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="404186" checksum="13">
+										<typ>ÅTG</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-05-07</handlingDatum>
+										<anteckning>L0360859</anteckning>
+										<uuid>c02499eb-9ac3-447f-bba4-fb8793a93565</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="555363" checksum="-1067989268">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Åtgärdsföreläggande</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="333492" checksum="37">
+								<riktning>Okänd</riktning>
+								<rubrik>Åtgärdsföreläggande L0360842</rubrik>
+								<startDatum>2020-05-07T13:08:00+02:00</startDatum>
+								<anteckning/>
+								<handelseslag>ÅTG</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="false">
+									<beslutstext/>
+									<delegatHandlaggare signatur="hel07sah">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgINSP</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="404188" checksum="34">
+										<typ>ÅTG</typ>
+										<status>Expedierad</status>
+										<handlingDatum>2020-05-07</handlingDatum>
+										<anteckning>L0360842</anteckning>
+										<uuid>a0281162-c389-4e4a-ab14-264b5dab1fdb</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="555365" checksum="-1067989268">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Åtgärdsföreläggande</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="333489" checksum="25">
+								<riktning>Okänd</riktning>
+								<rubrik>Tillsyn</rubrik>
+								<startDatum>2020-03-11T00:00:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>TILL</handelseslag>
+								<handelsetyp>ANM</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="404184" checksum="11">
+										<typ>HISSINT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-03-11</handlingDatum>
+										<anteckning>L0360842</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="555361" checksum="-856731286">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Hissintyg</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="404185" checksum="26">
+										<typ>HISSINT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-03-11</handlingDatum>
+										<anteckning>L0360859</anteckning>
+										<uuid>6bce494d-8a59-4622-b8c3-7f7d422ff066</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="555362" checksum="-136794136">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Hissintyg</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="341457" checksum="34">
+								<riktning>In</riktning>
+								<rubrik>Godkända hissintyg</rubrik>
+								<startDatum>2020-07-02T13:00:00+02:00</startDatum>
+								<anteckning/>
+								<handelsetyp>HANDLING</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="412175" checksum="3">
+										<typ>HISSINT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-07-02</handlingDatum>
+										<anteckning>Godkänd, L0360859</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="563509" checksum="444883367">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+									<handling handlingId="412176" checksum="2">
+										<typ>HISSINT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2020-07-02</handlingDatum>
+										<anteckning>Godkänd, L0360842</anteckning>
+										<makulerad>false</makulerad>
+										<dokument dokId="563510" checksum="-454090230">
+											<namn>Test Testorsson</namn>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+						</handelseLista>
+						<objektLista xmlns="www.tekis.se/arende">
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="51898"
+												  arHuvudObjekt="true"
+												  checksum="1|">
+								<belAdressList>
+									<arendeBelagenhetAdress arendeObjektId="51898">
+										<belAdress>
+											<adressOmrade>TEST</adressOmrade>
+											<adressPlatsNr>530</adressPlatsNr>
+										</belAdress>
+									</arendeBelagenhetAdress>
+								</belAdressList>
+								<fastighet checksum="-1069093451|" fnr="22041266">
+									<trakt>TEST</trakt>
+									<fbetNr>1:41</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+						</objektLista>
+					</arende>
+					<arende arendeId="42736" dnr="BYGG 2018-000026" diarieprefix="BYGG"
+							kommun="Sundsvall" enhet="SBK"
+							enhetkod="" arendegrupp="LOV" arendetyp="BL" arendeslag="A"
+							arendeklass="FRI" namndkod="SBN"
+							kalla="1">
+						<status xmlns="www.tekis.se/arende">Avslutat</status>
+						<beskrivning xmlns="www.tekis.se/arende">Bygglov Nybyggnad fritidshus
+							AVSKRIVET
+						</beskrivning>
+						<ankomstDatum xmlns="www.tekis.se/arende">2018-01-15</ankomstDatum>
+						<slutDatum xmlns="www.tekis.se/arende">2018-01-30</slutDatum>
+						<uppdateradDatum xmlns="www.tekis.se/arende">2021-12-17</uppdateradDatum>
+						<registreradDatum xmlns="www.tekis.se/arende">2018-01-15</registreradDatum>
+						<handlaggare handlaggareId="822" signatur="hel07sah"
+									 xmlns="www.tekis.se/arende">
+							<fornamn>Test</fornamn>
+							<fornamn>Testorsson</fornamn>
+						</handlaggare>
+						<intressentLista xmlns="www.tekis.se/arende">
+							<intressent intressentId="22231" attentionId="0"
+										intressentVersionId="29301">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn>Test</fornamn>
+								<fornamn>Testorsson</fornamn>
+								<attention/>
+								<rollLista>
+									<roll>FAG</roll>
+								</rollLista>
+							</intressent>
+							<intressent intressentId="22232" attentionId="0"
+										intressentVersionId="39187">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn>Test</fornamn>
+								<fornamn>Testorsson</fornamn>
+								<attention/>
+								<rollLista>
+									<roll>SOK</roll>
+								</rollLista>
+							</intressent>
+							<intressent intressentId="22230" attentionId="0"
+										intressentVersionId="29300">
+								<namn>Test Testorsson</namn>
+								<adress>Fiktiva Gatan 12</adress>
+								<coAdress/>
+								<postNr>123 45</postNr>
+								<ort>TEST</ort>
+								<land/>
+								<fornamn>Test</fornamn>
+								<fornamn>Testorsson</fornamn>
+								<attention/>
+								<rollLista>
+									<roll>FAG</roll>
+								</rollLista>
+							</intressent>
+						</intressentLista>
+						<handelseLista xmlns="www.tekis.se/arende">
+							<handelse handelseId="276911" checksum="25">
+								<riktning>In</riktning>
+								<rubrik>Bygglov</rubrik>
+								<startDatum>2018-01-15T08:51:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>Bygglov</handelseslag>
+								<handelsetyp>ANSÖKAN</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="328921" checksum="62">
+										<typ>ANS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431169" checksum="-427559378">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Ansökan om bygglov</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="328922" checksum="46">
+										<typ>FAPL</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431174" checksum="-507595760">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Fasad plan sektion</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="328923" checksum="12">
+										<typ>FPSS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431173" checksum="1955768040">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Fasad plan sektion situationsplan
+											</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="328924" checksum="49">
+										<typ>UKON</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431175" checksum="-1965431634">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Konstruktionshandlingar</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="328925" checksum="14">
+										<typ>SEKT</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431171" checksum="14858542">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Sektioner</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="328926" checksum="30">
+										<typ>SITU</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431170" checksum="2076100622">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Situationsplan</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="328928" checksum="36">
+										<typ>FÖLJ</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<anteckning>Ärendeblad</anteckning>
+										<uuid>72cfb195-0b91-42b1-bb22-1f971c91f816</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="431176" checksum="233089522">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Följebrev</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="277833" checksum="54">
+								<riktning>Okänd</riktning>
+								<rubrik>Avskrivning, Avslutas</rubrik>
+								<startDatum>2018-01-30T12:23:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>UAB</handelseslag>
+								<handelsetyp>BESLUT</handelsetyp>
+								<handelseutfall>AVSL</handelseutfall>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<beslut arHuvudbeslut="true">
+									<beslutstext/>
+									<delegatHandlaggare signatur="ann31jer">
+										<fornamn>Test</fornamn>
+										<fornamn>Testorsson</fornamn>
+									</delegatHandlaggare>
+									<instanstyp>DelgSTA</instanstyp>
+								</beslut>
+								<handlingLista>
+									<handling handlingId="330161" checksum="52">
+										<typ>@BESLUT</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2018-01-30</handlingDatum>
+										<uuid>5415483d-007a-4ef6-93c2-8e59caab09e5</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="433467" checksum="-1465822860">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Beslut</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>true</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+							<handelse handelseId="362930" checksum="0">
+								<riktning>Ut</riktning>
+								<rubrik>Arkiveras i Formpipe</rubrik>
+								<startDatum>2018-01-30T15:14:00+01:00</startDatum>
+								<anteckning/>
+								<handelseslag>FORMPIPE</handelseslag>
+								<handelsetyp>ARKIV</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="328921" checksum="62">
+										<typ>ANS</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-15</handlingDatum>
+										<makulerad>false</makulerad>
+										<dokument dokId="431169" checksum="-427559378">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Ansökan om bygglov</beskrivning>
+										</dokument>
+									</handling>
+									<handling handlingId="330161" checksum="52">
+										<typ>@BESLUT</typ>
+										<status>Arbetsmtrl</status>
+										<handlingDatum>2018-01-30</handlingDatum>
+										<uuid>5415483d-007a-4ef6-93c2-8e59caab09e5</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="433467" checksum="-1465822860">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Beslut</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>false</arbetsmaterial>
+								<handlaggare signatur="maj27nym"/>
+							</handelse>
+							<handelse handelseId="277834" checksum="57">
+								<riktning>Ut</riktning>
+								<rubrik>Skrivelse från sökande</rubrik>
+								<startDatum>2018-01-23T12:31:00+01:00</startDatum>
+								<anteckning/>
+								<handelsetyp>HANDLING</handelsetyp>
+								<sekretess>false</sekretess>
+								<makulerad>false</makulerad>
+								<handlingLista>
+									<handling handlingId="330162" checksum="5">
+										<typ>SKR</typ>
+										<status>Inkommen</status>
+										<handlingDatum>2018-01-23</handlingDatum>
+										<uuid>8d0eb5cf-79a1-416f-a9db-feed99d7b26c</uuid>
+										<makulerad>false</makulerad>
+										<dokument dokId="433468" checksum="1840526893">
+											<namn>Test Testorsson</namn>
+											<beskrivning>Skrivelse</beskrivning>
+										</dokument>
+									</handling>
+								</handlingLista>
+								<arbetsmaterial>true</arbetsmaterial>
+								<handlaggare signatur="hel07sah"/>
+							</handelse>
+						</handelseLista>
+						<objektLista xmlns="www.tekis.se/arende">
+							<abstractArendeObjekt xsi:type="arendeFastighet" arendeObjektId="43397"
+												  arHuvudObjekt="true"
+												  checksum="1|">
+								<fastighet checksum="1294563468|" fnr="22047495">
+									<trakt>TEST</trakt>
+									<fbetNr>3:6</fbetNr>
+								</fastighet>
+							</abstractArendeObjekt>
+						</objektLista>
+					</arende>
+				</Arenden>
+			</GetUpdatedArendenResult>
+		</GetUpdatedArendenResponse>
+	</s:Body>
+</s:Envelope>

--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -8,7 +8,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "2.0"
 servers:
-- url: http://localhost:50804
+- url: http://localhost:62822
   description: Generated server url
 paths:
   /{municipalityId}/batch-jobs:
@@ -139,6 +139,65 @@ paths:
                 $ref: "#/components/schemas/Problem"
         "404":
           description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /{municipalityId}/batch-jobs/{batchHistoryId}/fallout:
+    get:
+      tags:
+      - byggr-archiver-resource
+      operationId: getFallout
+      parameters:
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: batchHistoryId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: category
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - FILE_TOO_LARGE
+          - ARCHIVE_REJECTED_FORMAT
+          - ARCHIVE_ERROR
+          - BYGGR_FETCH_ERROR
+          - METADATA_ERROR
+          - UNKNOWN
+      responses:
+        "200":
+          description: OK - Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ArchiveFailureResponse"
+            application/problem+json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ArchiveFailureResponse"
+        "400":
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "500":
+          description: Internal Server error
           content:
             application/problem+json:
               schema:
@@ -320,6 +379,39 @@ components:
           enum:
           - MANUAL
           - SCHEDULED
+        timestamp:
+          type: string
+          format: date-time
+    ArchiveFailureResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        batchHistoryId:
+          type: integer
+          format: int64
+        caseId:
+          type: string
+        documentId:
+          type: string
+        municipalityId:
+          type: string
+        documentName:
+          type: string
+        failureCategory:
+          type: string
+          enum:
+          - FILE_TOO_LARGE
+          - ARCHIVE_REJECTED_FORMAT
+          - ARCHIVE_ERROR
+          - BYGGR_FETCH_ERROR
+          - METADATA_ERROR
+          - UNKNOWN
+        message:
+          type: string
+        detail:
+          type: string
         timestamp:
           type: string
           format: date-time

--- a/src/main/java/se/sundsvall/byggrarchiver/api/ByggrArchiverResource.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/api/ByggrArchiverResource.java
@@ -25,7 +25,7 @@ import se.sundsvall.byggrarchiver.api.model.enums.BatchTrigger;
 import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
 import se.sundsvall.byggrarchiver.api.validation.StartBeforeEnd;
 import se.sundsvall.byggrarchiver.service.ArchiveFailureService;
-import se.sundsvall.byggrarchiver.service.ArchiveHistoryService;
+import se.sundsvall.byggrarchiver.service.ArchiveHistoryQueryService;
 import se.sundsvall.byggrarchiver.service.ByggrArchiverService;
 import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
 import se.sundsvall.dept44.problem.Problem;
@@ -48,17 +48,17 @@ class ByggrArchiverResource {
 
 	private final ByggrArchiverService byggrArchiverService;
 
-	private final ArchiveHistoryService archiveHistoryService;
+	private final ArchiveHistoryQueryService archiveHistoryQueryService;
 
 	private final ArchiveFailureService archiveFailureService;
 
 	ByggrArchiverResource(final ByggrArchiverService byggrArchiverService,
 
-		final ArchiveHistoryService archiveHistoryService,
+		final ArchiveHistoryQueryService archiveHistoryQueryService,
 
 		final ArchiveFailureService archiveFailureService) {
 		this.byggrArchiverService = byggrArchiverService;
-		this.archiveHistoryService = archiveHistoryService;
+		this.archiveHistoryQueryService = archiveHistoryQueryService;
 		this.archiveFailureService = archiveFailureService;
 	}
 
@@ -67,7 +67,7 @@ class ByggrArchiverResource {
 		@Parameter(name = "municipalityId", description = "Municipality id", example = "2281") @ValidMunicipalityId @PathVariable final String municipalityId,
 		@RequestParam(value = "archiveStatus", required = false) final ArchiveStatus archiveStatus,
 		@RequestParam(value = "batchHistoryId", required = false) final Long batchHistoryId) {
-		return ResponseEntity.ok(archiveHistoryService.getArchiveHistories(archiveStatus, batchHistoryId, municipalityId));
+		return ResponseEntity.ok(archiveHistoryQueryService.getArchiveHistories(archiveStatus, batchHistoryId, municipalityId));
 	}
 
 	@GetMapping("/batch-jobs")

--- a/src/main/java/se/sundsvall/byggrarchiver/api/ByggrArchiverResource.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/api/ByggrArchiverResource.java
@@ -16,12 +16,15 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import se.sundsvall.byggrarchiver.api.model.ArchiveFailureResponse;
 import se.sundsvall.byggrarchiver.api.model.ArchiveHistoryResponse;
 import se.sundsvall.byggrarchiver.api.model.BatchHistoryResponse;
 import se.sundsvall.byggrarchiver.api.model.BatchJob;
 import se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus;
 import se.sundsvall.byggrarchiver.api.model.enums.BatchTrigger;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
 import se.sundsvall.byggrarchiver.api.validation.StartBeforeEnd;
+import se.sundsvall.byggrarchiver.service.ArchiveFailureService;
 import se.sundsvall.byggrarchiver.service.ArchiveHistoryService;
 import se.sundsvall.byggrarchiver.service.ByggrArchiverService;
 import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
@@ -47,11 +50,16 @@ class ByggrArchiverResource {
 
 	private final ArchiveHistoryService archiveHistoryService;
 
+	private final ArchiveFailureService archiveFailureService;
+
 	ByggrArchiverResource(final ByggrArchiverService byggrArchiverService,
 
-		final ArchiveHistoryService archiveHistoryService) {
+		final ArchiveHistoryService archiveHistoryService,
+
+		final ArchiveFailureService archiveFailureService) {
 		this.byggrArchiverService = byggrArchiverService;
 		this.archiveHistoryService = archiveHistoryService;
+		this.archiveFailureService = archiveFailureService;
 	}
 
 	@GetMapping("/archived/attachments")
@@ -83,6 +91,14 @@ class ByggrArchiverResource {
 		final var result = byggrArchiverService.reRunBatch(batchHistoryId, municipalityId);
 
 		return ResponseEntity.ok((result));
+	}
+
+	@GetMapping("/batch-jobs/{batchHistoryId}/fallout")
+	ResponseEntity<List<ArchiveFailureResponse>> getFallout(
+		@Parameter(name = "municipalityId", description = "Municipality id", example = "2281") @ValidMunicipalityId @PathVariable final String municipalityId,
+		@PathVariable("batchHistoryId") final Long batchHistoryId,
+		@RequestParam(value = "category", required = false) final FailureCategory category) {
+		return ResponseEntity.ok(archiveFailureService.getFailures(batchHistoryId, category, municipalityId));
 	}
 
 }

--- a/src/main/java/se/sundsvall/byggrarchiver/api/model/ArchiveFailureResponse.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/api/model/ArchiveFailureResponse.java
@@ -1,16 +1,13 @@
 package se.sundsvall.byggrarchiver.api.model;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
 
-@Setter
-@Getter
+@Data
 @Builder(setterPrefix = "with")
 @NoArgsConstructor
 @AllArgsConstructor()
@@ -35,37 +32,4 @@ public class ArchiveFailureResponse {
 	private String detail;
 
 	private LocalDateTime timestamp;
-
-	@Override
-	public boolean equals(final Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		final ArchiveFailureResponse that = (ArchiveFailureResponse) o;
-		return Objects.equals(id, that.id) && Objects.equals(batchHistoryId, that.batchHistoryId) && Objects.equals(caseId, that.caseId) && Objects.equals(documentId, that.documentId) && Objects.equals(municipalityId, that.municipalityId) && Objects
-			.equals(documentName, that.documentName) && failureCategory == that.failureCategory && Objects.equals(message, that.message) && Objects.equals(detail, that.detail) && Objects.equals(timestamp, that.timestamp);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(id, batchHistoryId, caseId, documentId, municipalityId, documentName, failureCategory, message, detail, timestamp);
-	}
-
-	@Override
-	public String toString() {
-		return "ArchiveFailureResponse{" +
-			"id=" + id +
-			", batchHistoryId=" + batchHistoryId +
-			", caseId='" + caseId + '\'' +
-			", documentId='" + documentId + '\'' +
-			", municipalityId='" + municipalityId + '\'' +
-			", documentName='" + documentName + '\'' +
-			", failureCategory=" + failureCategory +
-			", message='" + message + '\'' +
-			", detail='" + detail + '\'' +
-			", timestamp=" + timestamp +
-			'}';
-	}
-
 }

--- a/src/main/java/se/sundsvall/byggrarchiver/api/model/ArchiveFailureResponse.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/api/model/ArchiveFailureResponse.java
@@ -1,0 +1,71 @@
+package se.sundsvall.byggrarchiver.api.model;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+
+@Setter
+@Getter
+@Builder(setterPrefix = "with")
+@NoArgsConstructor
+@AllArgsConstructor()
+public class ArchiveFailureResponse {
+
+	private Long id;
+
+	private Long batchHistoryId;
+
+	private String caseId;
+
+	private String documentId;
+
+	private String municipalityId;
+
+	private String documentName;
+
+	private FailureCategory failureCategory;
+
+	private String message;
+
+	private String detail;
+
+	private LocalDateTime timestamp;
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		final ArchiveFailureResponse that = (ArchiveFailureResponse) o;
+		return Objects.equals(id, that.id) && Objects.equals(batchHistoryId, that.batchHistoryId) && Objects.equals(caseId, that.caseId) && Objects.equals(documentId, that.documentId) && Objects.equals(municipalityId, that.municipalityId) && Objects
+			.equals(documentName, that.documentName) && failureCategory == that.failureCategory && Objects.equals(message, that.message) && Objects.equals(detail, that.detail) && Objects.equals(timestamp, that.timestamp);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, batchHistoryId, caseId, documentId, municipalityId, documentName, failureCategory, message, detail, timestamp);
+	}
+
+	@Override
+	public String toString() {
+		return "ArchiveFailureResponse{" +
+			"id=" + id +
+			", batchHistoryId=" + batchHistoryId +
+			", caseId='" + caseId + '\'' +
+			", documentId='" + documentId + '\'' +
+			", municipalityId='" + municipalityId + '\'' +
+			", documentName='" + documentName + '\'' +
+			", failureCategory=" + failureCategory +
+			", message='" + message + '\'' +
+			", detail='" + detail + '\'' +
+			", timestamp=" + timestamp +
+			'}';
+	}
+
+}

--- a/src/main/java/se/sundsvall/byggrarchiver/api/model/ArchiveHistoryResponse.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/api/model/ArchiveHistoryResponse.java
@@ -1,16 +1,13 @@
 package se.sundsvall.byggrarchiver.api.model;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus;
 
-@Setter
-@Getter
+@Data
 @Builder(setterPrefix = "with")
 @NoArgsConstructor
 @AllArgsConstructor()
@@ -33,36 +30,4 @@ public class ArchiveHistoryResponse {
 	private LocalDateTime timestamp;
 
 	private BatchHistoryResponse batchHistory;
-
-	@Override
-	public boolean equals(final Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		final ArchiveHistoryResponse that = (ArchiveHistoryResponse) o;
-		return Objects.equals(documentId, that.documentId) && Objects.equals(caseId, that.caseId) && Objects.equals(documentName, that.documentName) && Objects.equals(documentType, that.documentType) && Objects.equals(archiveId, that.archiveId) && Objects
-			.equals(archiveUrl, that.archiveUrl) && archiveStatus == that.archiveStatus && Objects.equals(timestamp, that.timestamp) && Objects.equals(batchHistory, that.batchHistory);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(documentId, caseId, documentName, documentType, archiveId, archiveUrl, archiveStatus, timestamp, batchHistory);
-	}
-
-	@Override
-	public String toString() {
-		return "ArchiveHistoryResponse{" +
-			"documentId='" + documentId + '\'' +
-			", caseId='" + caseId + '\'' +
-			", documentName='" + documentName + '\'' +
-			", documentType='" + documentType + '\'' +
-			", archiveId='" + archiveId + '\'' +
-			", archiveUrl='" + archiveUrl + '\'' +
-			", archiveStatus=" + archiveStatus +
-			", timestamp=" + timestamp +
-			", batchHistory=" + batchHistory +
-			'}';
-	}
-
 }

--- a/src/main/java/se/sundsvall/byggrarchiver/api/model/BatchHistoryResponse.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/api/model/BatchHistoryResponse.java
@@ -2,17 +2,14 @@ package se.sundsvall.byggrarchiver.api.model;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus;
 import se.sundsvall.byggrarchiver.api.model.enums.BatchTrigger;
 
-@Setter
-@Getter
+@Data
 @Builder(setterPrefix = "with")
 @NoArgsConstructor
 @AllArgsConstructor()
@@ -29,36 +26,4 @@ public class BatchHistoryResponse {
 	private BatchTrigger batchTrigger;
 
 	private LocalDateTime timestamp;
-
-	@Override
-	public boolean equals(final Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		final BatchHistoryResponse that = (BatchHistoryResponse) o;
-		return Objects.equals(id, that.id) && Objects.equals(start, that.start) && Objects.equals(end, that.end) && archiveStatus == that.archiveStatus && batchTrigger == that.batchTrigger && Objects.equals(timestamp, that.timestamp);
-	}
-
-	@Override
-
-	public int hashCode() {
-
-		return Objects.hash(id, start
-
-			, end, archiveStatus, batchTrigger, timestamp);
-	}
-
-	@Override
-	public String toString() {
-		return "BatchHistoryResponse{" +
-			"id=" + id +
-			", start=" + start +
-			", end=" + end +
-			", archiveStatus=" + archiveStatus +
-			", batchTrigger=" + batchTrigger +
-			", timestamp=" + timestamp +
-			'}';
-	}
-
 }

--- a/src/main/java/se/sundsvall/byggrarchiver/api/model/enums/FailureCategory.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/api/model/enums/FailureCategory.java
@@ -1,0 +1,10 @@
+package se.sundsvall.byggrarchiver.api.model.enums;
+
+public enum FailureCategory {
+	FILE_TOO_LARGE,
+	ARCHIVE_REJECTED_FORMAT,
+	ARCHIVE_ERROR,
+	BYGGR_FETCH_ERROR,
+	METADATA_ERROR,
+	UNKNOWN
+}

--- a/src/main/java/se/sundsvall/byggrarchiver/configuration/PropertiesConfiguration.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/configuration/PropertiesConfiguration.java
@@ -1,6 +1,8 @@
 package se.sundsvall.byggrarchiver.configuration;
 
+import java.time.Clock;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -8,5 +10,10 @@ import org.springframework.context.annotation.Configuration;
 	LongTermArchiveProperties.class, EmailProperties.class
 })
 class PropertiesConfiguration {
+
+	@Bean
+	Clock clock() {
+		return Clock.systemDefaultZone();
+	}
 
 }

--- a/src/main/java/se/sundsvall/byggrarchiver/integration/db/ArchiveFailureRepository.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/integration/db/ArchiveFailureRepository.java
@@ -1,0 +1,19 @@
+package se.sundsvall.byggrarchiver.integration.db;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveFailure;
+
+@Transactional
+@CircuitBreaker(name = "archiveFailureRepository")
+public interface ArchiveFailureRepository extends JpaRepository<ArchiveFailure, Long> {
+
+	@Query("select f from ArchiveFailure f where f.batchHistoryId = :batchHistoryId and f.municipalityId = :municipalityId and (:failureCategory is null or f.failureCategory = :failureCategory)")
+	List<ArchiveFailure> findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(@Param("batchHistoryId") Long batchHistoryId, @Param("municipalityId") String municipalityId, @Param("failureCategory") FailureCategory failureCategory);
+
+}

--- a/src/main/java/se/sundsvall/byggrarchiver/integration/db/model/ArchiveFailure.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/integration/db/model/ArchiveFailure.java
@@ -1,0 +1,112 @@
+package se.sundsvall.byggrarchiver.integration.db.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+
+@Entity
+@Builder(setterPrefix = "with")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "archive_failure", indexes = {
+	@Index(name = "archive_failure_batch_history_id_idx", columnList = "batchHistoryId"),
+	@Index(name = "archive_failure_municipality_id_idx", columnList = "municipalityId"),
+	@Index(name = "archive_failure_failure_category_idx", columnList = "failureCategory")
+})
+public class ArchiveFailure {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Schema(accessMode = Schema.AccessMode.READ_ONLY)
+	@Column(nullable = false)
+	private Long id;
+
+	@Column(nullable = false)
+	private Long batchHistoryId;
+
+	@Column(nullable = false)
+	private String caseId;
+
+	@Column
+	private String documentId;
+
+	@Column
+	private String municipalityId;
+
+	@Column
+	private String documentName;
+
+	@Column(nullable = false, columnDefinition = "varchar(255)")
+	@Enumerated(EnumType.STRING)
+	private FailureCategory failureCategory;
+
+	@Column(columnDefinition = "varchar(255)")
+	private String message;
+
+	@Column(columnDefinition = "longtext")
+	private String detail;
+
+	@Schema(accessMode = Schema.AccessMode.READ_ONLY)
+	@Column(nullable = false)
+	private LocalDateTime timestamp;
+
+	@PrePersist
+	@PreUpdate
+	protected void onPersist() {
+		timestamp = LocalDateTime.now(ZoneId.systemDefault()).truncatedTo(ChronoUnit.MICROS);
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		final ArchiveFailure that = (ArchiveFailure) o;
+		return Objects.equals(id, that.id) && Objects.equals(batchHistoryId, that.batchHistoryId) && Objects.equals(caseId, that.caseId) && Objects.equals(documentId, that.documentId) && Objects.equals(municipalityId, that.municipalityId) && Objects
+			.equals(documentName, that.documentName) && failureCategory == that.failureCategory && Objects.equals(message, that.message) && Objects.equals(detail, that.detail) && Objects.equals(timestamp, that.timestamp);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, batchHistoryId, caseId, documentId, municipalityId, documentName, failureCategory, message, detail, timestamp);
+	}
+
+	@Override
+	public String toString() {
+		return "ArchiveFailure{" +
+			"id=" + id +
+			", batchHistoryId=" + batchHistoryId +
+			", caseId='" + caseId + '\'' +
+			", documentId='" + documentId + '\'' +
+			", municipalityId='" + municipalityId + '\'' +
+			", documentName='" + documentName + '\'' +
+			", failureCategory=" + failureCategory +
+			", message='" + message + '\'' +
+			", detail='" + detail + '\'' +
+			", timestamp=" + timestamp +
+			'}';
+	}
+
+}

--- a/src/main/java/se/sundsvall/byggrarchiver/integration/db/model/ArchiveFailure.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/integration/db/model/ArchiveFailure.java
@@ -45,7 +45,9 @@ public class ArchiveFailure {
 	@Column(nullable = false)
 	private Long batchHistoryId;
 
-	@Column(nullable = false)
+	// Nullable on purpose: a failure whose case has no dnr is still worth auditing - never let a null caseId
+	// drop the audit row via a constraint violation.
+	@Column
 	private String caseId;
 
 	@Column

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentService.java
@@ -10,6 +10,7 @@ import generated.se.sundsvall.bygglov.ObjectFactory;
 import jakarta.xml.bind.JAXBContext;
 import java.io.StringWriter;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Map;
 import org.apache.commons.text.StringSubstitutor;
 import org.slf4j.Logger;
@@ -134,7 +135,7 @@ public class ArchiveAttachmentService {
 			arkivobjektArende.getFastighet().add(fbIntegration.getFastighet(arendeFastighetList));
 		}
 
-		if ((arende.getAnkomstDatum() == null) || arende.getAnkomstDatum().isAfter(LocalDate.of(2016, 12, 31))) {
+		if ((arende.getAnkomstDatum() == null) || arende.getAnkomstDatum().isAfter(LocalDate.of(2016, Month.DECEMBER, 31))) {
 			arkivobjektArende.getKlass().add(HANTERA_BYGGLOV);
 		} else {
 			arkivobjektArende.getKlass().add(F_2_BYGGLOV);

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentService.java
@@ -86,8 +86,7 @@ public class ArchiveAttachmentService {
 				messagingIntegration.sendExtensionErrorEmail(archiveHistory, municipalityId);
 			}
 
-			archiveFailureRecorder.record(formatRejection ? ARCHIVE_REJECTED_FORMAT : ARCHIVE_ERROR, archiveHistory.getCaseId(), archiveHistory.getDocumentId(), archiveHistory.getDocumentName(), archiveHistory.getBatchHistory().getId(), municipalityId,
-				formatRejection ? "Archive rejected file format" : "Archive request failed", e.getMessage());
+			archiveFailureRecorder.recordFailure(formatRejection ? ARCHIVE_REJECTED_FORMAT : ARCHIVE_ERROR, archiveHistory, formatRejection ? "Archive rejected file format" : "Archive request failed", e.getMessage());
 			failureRecorded = true;
 		}
 
@@ -106,8 +105,7 @@ public class ArchiveAttachmentService {
 
 			// Only record here when the failure wasn't already recorded in the catch above (avoids a duplicate row)
 			if (!failureRecorded) {
-				archiveFailureRecorder.record(ARCHIVE_ERROR, archiveHistory.getCaseId(), archiveHistory.getDocumentId(), archiveHistory.getDocumentName(), archiveHistory.getBatchHistory().getId(), municipalityId, "No archive id returned",
-					"archiveResponse=" + archiveResponse);
+				archiveFailureRecorder.recordFailure(ARCHIVE_ERROR, archiveHistory, "No archive id returned", "archiveResponse=" + archiveResponse);
 			}
 		}
 

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentService.java
@@ -28,6 +28,8 @@ import se.sundsvall.dept44.exception.ServerProblem;
 import static java.util.Optional.ofNullable;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.ARCHIVE_ERROR;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.ARCHIVE_REJECTED_FORMAT;
 import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.toArendeFastighetList;
 import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.toArkivbildarStruktur;
 import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.toArkivobjektArendeTyp;
@@ -50,33 +52,43 @@ public class ArchiveAttachmentService {
 
 	private final FbIntegration fbIntegration;
 
+	private final ArchiveFailureRecorder archiveFailureRecorder;
+
 	LongTermArchiveProperties longTermArchiveProperties;
 
 	public ArchiveAttachmentService(final LongTermArchiveProperties longTermArchiveProperties, final ArchiveHistoryRepository archiveHistoryRepository,
-		final MessagingIntegration messagingIntegration, final ArchiveIntegration archiveIntegration, final FbIntegration fbIntegration) {
+		final MessagingIntegration messagingIntegration, final ArchiveIntegration archiveIntegration, final FbIntegration fbIntegration, final ArchiveFailureRecorder archiveFailureRecorder) {
 		this.longTermArchiveProperties = longTermArchiveProperties;
 		this.archiveHistoryRepository = archiveHistoryRepository;
 		this.messagingIntegration = messagingIntegration;
 		this.archiveIntegration = archiveIntegration;
 		this.fbIntegration = fbIntegration;
+		this.archiveFailureRecorder = archiveFailureRecorder;
 	}
 
 	public ArchiveHistory archiveAttachment(final Arende2 arende, final Handling handling, final Dokument document, final ArchiveHistory archiveHistory, final String municipalityId) throws ApplicationException {
 
 		// Request to Archive
 		ArchiveResponse archiveResponse = null;
+		var failureRecorded = false;
 		try {
 			archiveResponse = archiveIntegration.archive(toByggRArchiveRequest(document, createMetadata(arende, handling, document)), municipalityId);
 		} catch (final ClientProblem | ServerProblem e) {
 			LOG.error("Request to Archive failed. Continue with the rest.", e);
 
-			if (e.getMessage().contains("extension must be valid") ||
+			final var formatRejection = e.getMessage().contains("extension must be valid") ||
 				e.getMessage().contains("File format") ||
-				e.getMessage().contains("PreservationObjectConversionException")) {
+				e.getMessage().contains("PreservationObjectConversionException");
+
+			if (formatRejection) {
 				LOG.debug("The problem was related to the file extension. Send email with the information.");
 
 				messagingIntegration.sendExtensionErrorEmail(archiveHistory, municipalityId);
 			}
+
+			archiveFailureRecorder.record(formatRejection ? ARCHIVE_REJECTED_FORMAT : ARCHIVE_ERROR, archiveHistory.getCaseId(), archiveHistory.getDocumentId(), archiveHistory.getDocumentName(), archiveHistory.getBatchHistory().getId(), municipalityId,
+				formatRejection ? "Archive rejected file format" : "Archive request failed", e.getMessage());
+			failureRecorded = true;
 		}
 
 		if ((archiveResponse != null) && (archiveResponse.getArchiveId() != null)) {
@@ -91,6 +103,12 @@ public class ArchiveAttachmentService {
 			LOG.info("The archive-process of document with ID: {} did not succeed.", archiveHistory.getDocumentId());
 
 			archiveHistory.setArchiveStatus(NOT_COMPLETED);
+
+			// Only record here when the failure wasn't already recorded in the catch above (avoids a duplicate row)
+			if (!failureRecorded) {
+				archiveFailureRecorder.record(ARCHIVE_ERROR, archiveHistory.getCaseId(), archiveHistory.getDocumentId(), archiveHistory.getDocumentName(), archiveHistory.getBatchHistory().getId(), municipalityId, "No archive id returned",
+					"archiveResponse=" + archiveResponse);
+			}
 		}
 
 		return archiveHistoryRepository.save(archiveHistory);

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveFailureRecorder.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveFailureRecorder.java
@@ -1,0 +1,33 @@
+package se.sundsvall.byggrarchiver.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+
+/**
+ * Best-effort recorder for the append-only archive failure audit log. Recording a failure must never break the
+ * archiving pipeline, so every persist is wrapped and any error is swallowed (logged only). The persist itself runs in
+ * a separate transaction (see {@link ArchiveFailureService#persist}); the cross-bean call ensures the
+ * {@code REQUIRES_NEW} boundary is honored.
+ */
+@Component
+public class ArchiveFailureRecorder {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ArchiveFailureRecorder.class);
+
+	private final ArchiveFailureService archiveFailureService;
+
+	public ArchiveFailureRecorder(final ArchiveFailureService archiveFailureService) {
+		this.archiveFailureService = archiveFailureService;
+	}
+
+	public void record(final FailureCategory failureCategory, final String caseId, final String documentId, final String documentName, final Long batchHistoryId, final String municipalityId, final String message, final String detail) {
+		try {
+			archiveFailureService.persist(failureCategory, caseId, documentId, documentName, batchHistoryId, municipalityId, message, detail);
+		} catch (final Exception e) {
+			LOG.error("Failed to record archive failure (category={}, caseId={}, documentId={})", failureCategory, caseId, documentId, e);
+		}
+	}
+
+}

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveFailureRecorder.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveFailureRecorder.java
@@ -4,6 +4,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
+import se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper;
 
 /**
  * Best-effort recorder for the append-only archive failure audit log. Recording a failure must never break the
@@ -22,11 +24,16 @@ public class ArchiveFailureRecorder {
 		this.archiveFailureService = archiveFailureService;
 	}
 
-	public void record(final FailureCategory failureCategory, final String caseId, final String documentId, final String documentName, final Long batchHistoryId, final String municipalityId, final String message, final String detail) {
+	/**
+	 * Records a failure for the document the given {@link ArchiveHistory} represents. All identity (caseId, documentId,
+	 * documentName, batchHistoryId, municipalityId) is taken from the entity, so callers only supply the category and a
+	 * human-readable message + detail.
+	 */
+	public void recordFailure(final FailureCategory failureCategory, final ArchiveHistory archiveHistory, final String message, final String detail) {
 		try {
-			archiveFailureService.persist(failureCategory, caseId, documentId, documentName, batchHistoryId, municipalityId, message, detail);
+			archiveFailureService.persist(ArchiverMapper.toArchiveFailure(failureCategory, archiveHistory, message, detail));
 		} catch (final Exception e) {
-			LOG.error("Failed to record archive failure (category={}, caseId={}, documentId={})", failureCategory, caseId, documentId, e);
+			LOG.error("Failed to record archive failure (category={}, caseId={}, documentId={})", failureCategory, archiveHistory.getCaseId(), archiveHistory.getDocumentId(), e);
 		}
 	}
 

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveFailureService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveFailureService.java
@@ -1,0 +1,39 @@
+package se.sundsvall.byggrarchiver.service;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import se.sundsvall.byggrarchiver.api.model.ArchiveFailureResponse;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+import se.sundsvall.byggrarchiver.integration.db.ArchiveFailureRepository;
+import se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper;
+
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+
+@Service
+public class ArchiveFailureService {
+
+	private final ArchiveFailureRepository archiveFailureRepository;
+
+	public ArchiveFailureService(final ArchiveFailureRepository archiveFailureRepository) {
+		this.archiveFailureRepository = archiveFailureRepository;
+	}
+
+	/**
+	 * Persists a single archive failure in its own transaction so the audit row survives even if the surrounding
+	 * archiving work is rolled back. Invoked through {@link ArchiveFailureRecorder} which guarantees this never breaks
+	 * the archiving pipeline.
+	 */
+	@Transactional(propagation = REQUIRES_NEW)
+	public void persist(final FailureCategory failureCategory, final String caseId, final String documentId, final String documentName, final Long batchHistoryId, final String municipalityId, final String message, final String detail) {
+		archiveFailureRepository.save(ArchiverMapper.toArchiveFailure(failureCategory, caseId, documentId, documentName, batchHistoryId, municipalityId, message, detail));
+	}
+
+	public List<ArchiveFailureResponse> getFailures(final Long batchHistoryId, final FailureCategory failureCategory, final String municipalityId) {
+		return archiveFailureRepository.findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(batchHistoryId, municipalityId, failureCategory)
+			.stream()
+			.map(ArchiverMapper::mapToArchiveFailureResponse)
+			.toList();
+	}
+
+}

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveFailureService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveFailureService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import se.sundsvall.byggrarchiver.api.model.ArchiveFailureResponse;
 import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
 import se.sundsvall.byggrarchiver.integration.db.ArchiveFailureRepository;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveFailure;
 import se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper;
 
 import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
@@ -25,8 +26,8 @@ public class ArchiveFailureService {
 	 * the archiving pipeline.
 	 */
 	@Transactional(propagation = REQUIRES_NEW)
-	public void persist(final FailureCategory failureCategory, final String caseId, final String documentId, final String documentName, final Long batchHistoryId, final String municipalityId, final String message, final String detail) {
-		archiveFailureRepository.save(ArchiverMapper.toArchiveFailure(failureCategory, caseId, documentId, documentName, batchHistoryId, municipalityId, message, detail));
+	public void persist(final ArchiveFailure archiveFailure) {
+		archiveFailureRepository.save(archiveFailure);
 	}
 
 	public List<ArchiveFailureResponse> getFailures(final Long batchHistoryId, final FailureCategory failureCategory, final String municipalityId) {

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryQueryService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryQueryService.java
@@ -1,0 +1,26 @@
+package se.sundsvall.byggrarchiver.service;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import se.sundsvall.byggrarchiver.api.model.ArchiveHistoryResponse;
+import se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus;
+import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
+import se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper;
+
+@Service
+public class ArchiveHistoryQueryService {
+
+	private final ArchiveHistoryRepository archiveHistoryRepository;
+
+	public ArchiveHistoryQueryService(final ArchiveHistoryRepository archiveHistoryRepository) {
+		this.archiveHistoryRepository = archiveHistoryRepository;
+	}
+
+	public List<ArchiveHistoryResponse> getArchiveHistories(final ArchiveStatus archiveStatus, final Long batchHistoryId, final String municipalityId) {
+		return archiveHistoryRepository.getArchiveHistoriesByArchiveStatusAndBatchHistoryIdAndMunicipalityId(archiveStatus, batchHistoryId, municipalityId)
+			.stream()
+			.map(ArchiverMapper::mapToArchiveHistoryResponse)
+			.toList();
+	}
+
+}

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryService.java
@@ -13,19 +13,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import se.sundsvall.byggrarchiver.api.model.ArchiveHistoryResponse;
-import se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus;
-import se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory;
 import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
 import se.sundsvall.byggrarchiver.integration.arendeexport.ArendeExportIntegration;
 import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
-import se.sundsvall.byggrarchiver.integration.db.BatchHistoryRepository;
 import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
 import se.sundsvall.byggrarchiver.integration.db.model.BatchHistory;
 import se.sundsvall.byggrarchiver.integration.fb.FbIntegration;
 import se.sundsvall.byggrarchiver.integration.messaging.MessagingIntegration;
 import se.sundsvall.byggrarchiver.service.exceptions.ApplicationException;
-import se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper;
 
 import static java.util.Optional.ofNullable;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
@@ -36,6 +31,7 @@ import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.BYGGR_F
 import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.FILE_TOO_LARGE;
 import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.METADATA_ERROR;
 import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.UNKNOWN;
+import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.getAttachmentCategory;
 import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.toArchiveHistory;
 import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.toArendeFastighetList;
 import static se.sundsvall.byggrarchiver.util.Constants.BYGGR_HANDELSETYP_ARKIV;
@@ -46,7 +42,6 @@ public class ArchiveHistoryService {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ArchiveHistoryService.class);
 
-	private final BatchHistoryRepository batchHistoryRepository;
 	private final ArchiveHistoryRepository archiveHistoryRepository;
 
 	private final ArendeExportIntegration arendeExportIntegration;
@@ -54,6 +49,7 @@ public class ArchiveHistoryService {
 	private final FbIntegration fbIntegration;
 
 	private final ArchiveAttachmentService archiveAttachmentService;
+	private final BatchCompletionService batchCompletionService;
 
 	private final ArchiveFailureRecorder archiveFailureRecorder;
 
@@ -61,20 +57,20 @@ public class ArchiveHistoryService {
 
 	private final Integer maximumFileSize;
 
-	public ArchiveHistoryService(final BatchHistoryRepository batchHistoryRepository,
-		final ArendeExportIntegration arendeExportIntegration,
+	public ArchiveHistoryService(final ArendeExportIntegration arendeExportIntegration,
 		final ArchiveHistoryRepository archiveHistoryRepository,
 		final MessagingIntegration messagingIntegration,
 		final ArchiveAttachmentService archiveAttachmentService,
+		final BatchCompletionService batchCompletionService,
 		final FbIntegration fbIntegration,
 		final ArchiveFailureRecorder archiveFailureRecorder,
 		final Clock clock,
 		@Value("${integration.archive.maximum-file-size}") final Integer maximumFileSize) {
-		this.batchHistoryRepository = batchHistoryRepository;
 		this.arendeExportIntegration = arendeExportIntegration;
 		this.archiveHistoryRepository = archiveHistoryRepository;
 		this.messagingIntegration = messagingIntegration;
 		this.archiveAttachmentService = archiveAttachmentService;
+		this.batchCompletionService = batchCompletionService;
 		this.fbIntegration = fbIntegration;
 		this.archiveFailureRecorder = archiveFailureRecorder;
 		this.clock = clock;
@@ -118,42 +114,9 @@ public class ArchiveHistoryService {
 				.forEach(handling -> processHandlingList(handling, closedCase, batchHistory, municipalityId)));
 		} while (batchFilter.getLowerExclusiveBound().isBefore(end));
 
-		final var archiveHistoriesRelatedToBatch = archiveHistoryRepository.getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(batchHistory.getId(), municipalityId);
-		if (archiveHistoriesRelatedToBatch.stream().allMatch(archiveHistory -> COMPLETED.equals(archiveHistory.getArchiveStatus()))) {
-			// Persist that this batch is completed
-			batchHistory.setArchiveStatus(COMPLETED);
-			batchHistoryRepository.save(batchHistory);
-		} else {
-			// Send email when batch is not completed
-			messagingIntegration.sendStatusMail(archiveHistoriesRelatedToBatch, batchHistory.getId(), municipalityId);
-		}
-
-		LOG.info("Batch with ID: {} is {}", batchHistory.getId(), batchHistory.getArchiveStatus());
-		LOG.info("Batch with ID: {} has {} archive histories", batchHistory.getId(), archiveHistoriesRelatedToBatch.size());
-
-		updateStatusOfOldBatchHistories(municipalityId);
+		batchCompletionService.completeBatch(batchHistory, municipalityId);
 
 		return batchHistory;
-	}
-
-	/**
-	 * Update the status of NOT_COMPLETED old batch histories to COMPLETED if all archive histories are COMPLETED
-	 */
-	private void updateStatusOfOldBatchHistories(final String municipalityId) {
-		final var notCompletedBatchHistories = batchHistoryRepository.findBatchHistoriesByArchiveStatusAndMunicipalityId(NOT_COMPLETED, municipalityId);
-
-		notCompletedBatchHistories.forEach(batchHistory -> {
-			final boolean allCompleted = archiveHistoryRepository.getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(batchHistory.getId(), municipalityId)
-				.stream()
-				.allMatch(archiveHistory -> COMPLETED.equals(archiveHistory.getArchiveStatus()));
-
-			if (allCompleted) {
-				batchHistory.setArchiveStatus(COMPLETED);
-				batchHistoryRepository.save(batchHistory);
-
-				LOG.info("Old batch with ID: {} was NOT_COMPLETED but is now COMPLETED", batchHistory.getId());
-			}
-		});
 	}
 
 	private LocalDateTime getEnd(final LocalDate searchEnd) {
@@ -175,17 +138,6 @@ public class ArchiveHistoryService {
 			filter.setLowerExclusiveBound(plusOneHour.isAfter(filter.getUpperInclusiveBound()) ? filter.getUpperInclusiveBound() : plusOneHour);
 		} else {
 			filter.setLowerExclusiveBound(arendeBatch.getBatchEnd().isAfter(filter.getUpperInclusiveBound()) ? filter.getUpperInclusiveBound() : arendeBatch.getBatchEnd());
-		}
-	}
-
-	private AttachmentCategory getAttachmentCategory(final String handlingsTyp) {
-		try {
-			return AttachmentCategory.fromCode(handlingsTyp);
-		} catch (final IllegalArgumentException e) {
-			// All the "handlingstyper" we don't recognize, we set to AttachmentCategory.BIL, which
-			// means they get the archiveClassification D, which means that they are not public in
-			// the archive
-			return AttachmentCategory.BIL;
 		}
 	}
 
@@ -270,12 +222,6 @@ public class ArchiveHistoryService {
 
 	private boolean isArchived(final ArchiveHistory archiveHistory) {
 		return (archiveHistory != null) && (archiveHistory.getArchiveId() != null);
-	}
-
-	public List<ArchiveHistoryResponse> getArchiveHistories(final ArchiveStatus archiveStatus, final Long batchHistoryId, final String municipalityId) {
-
-		return archiveHistoryRepository.getArchiveHistoriesByArchiveStatusAndBatchHistoryIdAndMunicipalityId(archiveStatus, batchHistoryId, municipalityId).stream()
-			.map(ArchiverMapper::mapToArchiveHistoryResponse).toList();
 	}
 
 }

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryService.java
@@ -26,7 +26,6 @@ import se.sundsvall.byggrarchiver.integration.fb.FbIntegration;
 import se.sundsvall.byggrarchiver.integration.messaging.MessagingIntegration;
 import se.sundsvall.byggrarchiver.service.exceptions.ApplicationException;
 import se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper;
-import se.sundsvall.dept44.problem.ThrowableProblem;
 
 import static java.util.Optional.ofNullable;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
@@ -216,8 +215,10 @@ public class ArchiveHistoryService {
 		final List<Dokument> dokumentList;
 		try {
 			dokumentList = arendeExportIntegration.getDocument(docId);
-		} catch (final ThrowableProblem e) {
-			// A failed document fetch must not abort the whole batch - record it and continue with the next document
+		} catch (final RuntimeException e) {
+			// A failed document fetch must not abort the whole batch - record it and continue with the next document.
+			// Catches both the Problem thrown on a SOAP fault and any other runtime failure from the Feign call
+			// (e.g. CircuitBreaker CallNotPermittedException when the arendeexport breaker is open).
 			LOG.error("Error when fetching document with ID: {} in combination with Case-ID: {}", docId, arende.getDnr(), e);
 			archiveFailureRecorder.record(BYGGR_FETCH_ERROR, arende.getDnr(), docId, handling.getDokument().getNamn(), batchHistory.getId(), municipalityId, "ByggR getDocument failed", e.getMessage());
 			return;

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryService.java
@@ -111,14 +111,7 @@ public class ArchiveHistoryService {
 				.filter(handelse -> BYGGR_HANDELSETYP_ARKIV.equals(handelse.getHandelsetyp()))
 				.flatMap(handelse -> handelse.getHandlingLista().getHandling().stream())
 				.filter(handelseHandling -> handelseHandling.getDokument() != null)
-				.forEach(handling -> {
-					try {
-						processHandlingList(handling, closedCase, batchHistory, municipalityId);
-					} catch (final ApplicationException e) {
-						LOG.error("Error when archiving document with ID: {} in combination with Case-ID: {}", handling.getDokument().getDokId(), closedCase.getDnr(), e);
-						archiveFailureRecorder.record(categoryForApplicationException(e), closedCase.getDnr(), handling.getDokument().getDokId(), handling.getDokument().getNamn(), batchHistory.getId(), municipalityId, "Archiving failed", e.getMessage());
-					}
-				}));
+				.forEach(handling -> processHandlingList(handling, closedCase, batchHistory, municipalityId)));
 		} while (batchFilter.getLowerExclusiveBound().isBefore(end));
 
 		final var archiveHistoriesRelatedToBatch = archiveHistoryRepository.getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(batchHistory.getId(), municipalityId);
@@ -199,7 +192,7 @@ public class ArchiveHistoryService {
 			.orElse(UNKNOWN);
 	}
 
-	private void processHandlingList(final HandelseHandling handling, final Arende2 arende, final BatchHistory batchHistory, final String municipalityId) throws ApplicationException {
+	private void processHandlingList(final HandelseHandling handling, final Arende2 arende, final BatchHistory batchHistory, final String municipalityId) {
 		final ArchiveHistory newArchiveHistory;
 		final var docId = handling.getDokument().getDokId();
 		final var oldArchiveHistory = archiveHistoryRepository.getArchiveHistoryByDocumentIdAndCaseIdAndMunicipalityId(docId, arende.getDnr(), municipalityId);
@@ -220,12 +213,17 @@ public class ArchiveHistoryService {
 			// Catches both the Problem thrown on a SOAP fault and any other runtime failure from the Feign call
 			// (e.g. CircuitBreaker CallNotPermittedException when the arendeexport breaker is open).
 			LOG.error("Error when fetching document with ID: {} in combination with Case-ID: {}", docId, arende.getDnr(), e);
-			archiveFailureRecorder.record(BYGGR_FETCH_ERROR, arende.getDnr(), docId, handling.getDokument().getNamn(), batchHistory.getId(), municipalityId, "ByggR getDocument failed", e.getMessage());
+			archiveFailureRecorder.recordFailure(BYGGR_FETCH_ERROR, newArchiveHistory, "ByggR getDocument failed", e.getMessage());
 			return;
 		}
 
-		// Archive documents
-		handleArchiving(dokumentList, arende, handling, newArchiveHistory, municipalityId);
+		// Archive documents - a failure for one document must not abort the rest of the batch
+		try {
+			handleArchiving(dokumentList, arende, handling, newArchiveHistory, municipalityId);
+		} catch (final ApplicationException e) {
+			LOG.error("Error when archiving document with ID: {} in combination with Case-ID: {}", docId, arende.getDnr(), e);
+			archiveFailureRecorder.recordFailure(categoryForApplicationException(e), newArchiveHistory, "Archiving failed", e.getMessage());
+		}
 	}
 
 	void handleArchiving(final List<Dokument> dokuments, final Arende2 arende, final HandelseHandling handling, final ArchiveHistory archiveHistory, final String municipalityId) throws ApplicationException {
@@ -243,7 +241,7 @@ public class ArchiveHistoryService {
 					NOT_COMPLETED_FILE_TO_LARGE);
 				archiveHistory.setArchiveStatus(NOT_COMPLETED_FILE_TO_LARGE);
 				archiveHistoryRepository.save(archiveHistory);
-				archiveFailureRecorder.record(FILE_TOO_LARGE, arende.getDnr(), dokument.getDokId(), dokument.getNamn(), archiveHistory.getBatchHistory().getId(), municipalityId, "File too large",
+				archiveFailureRecorder.recordFailure(FILE_TOO_LARGE, archiveHistory, "File too large",
 					"actual=" + dokument.getFil().getFilBuffer().length + " bytes, max=" + maximumFileSize + " bytes");
 				continue;
 			}

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryService.java
@@ -18,22 +18,18 @@ import se.sundsvall.byggrarchiver.integration.arendeexport.ArendeExportIntegrati
 import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
 import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
 import se.sundsvall.byggrarchiver.integration.db.model.BatchHistory;
-import se.sundsvall.byggrarchiver.integration.fb.FbIntegration;
-import se.sundsvall.byggrarchiver.integration.messaging.MessagingIntegration;
 import se.sundsvall.byggrarchiver.service.exceptions.ApplicationException;
 
 import static java.util.Optional.ofNullable;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED_FILE_TO_LARGE;
-import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.GEO;
 import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.BYGGR_FETCH_ERROR;
 import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.FILE_TOO_LARGE;
 import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.METADATA_ERROR;
 import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.UNKNOWN;
 import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.getAttachmentCategory;
 import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.toArchiveHistory;
-import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.toArendeFastighetList;
 import static se.sundsvall.byggrarchiver.util.Constants.BYGGR_HANDELSETYP_ARKIV;
 import static se.sundsvall.byggrarchiver.util.Constants.BYGGR_STATUS_AVSLUTAT;
 
@@ -45,11 +41,10 @@ public class ArchiveHistoryService {
 	private final ArchiveHistoryRepository archiveHistoryRepository;
 
 	private final ArendeExportIntegration arendeExportIntegration;
-	private final MessagingIntegration messagingIntegration;
-	private final FbIntegration fbIntegration;
 
 	private final ArchiveAttachmentService archiveAttachmentService;
 	private final BatchCompletionService batchCompletionService;
+	private final LantmaterietNotifier lantmaterietNotifier;
 
 	private final ArchiveFailureRecorder archiveFailureRecorder;
 
@@ -59,19 +54,17 @@ public class ArchiveHistoryService {
 
 	public ArchiveHistoryService(final ArendeExportIntegration arendeExportIntegration,
 		final ArchiveHistoryRepository archiveHistoryRepository,
-		final MessagingIntegration messagingIntegration,
 		final ArchiveAttachmentService archiveAttachmentService,
 		final BatchCompletionService batchCompletionService,
-		final FbIntegration fbIntegration,
+		final LantmaterietNotifier lantmaterietNotifier,
 		final ArchiveFailureRecorder archiveFailureRecorder,
 		final Clock clock,
 		@Value("${integration.archive.maximum-file-size}") final Integer maximumFileSize) {
 		this.arendeExportIntegration = arendeExportIntegration;
 		this.archiveHistoryRepository = archiveHistoryRepository;
-		this.messagingIntegration = messagingIntegration;
 		this.archiveAttachmentService = archiveAttachmentService;
 		this.batchCompletionService = batchCompletionService;
-		this.fbIntegration = fbIntegration;
+		this.lantmaterietNotifier = lantmaterietNotifier;
 		this.archiveFailureRecorder = archiveFailureRecorder;
 		this.clock = clock;
 		this.maximumFileSize = maximumFileSize;
@@ -208,15 +201,7 @@ public class ArchiveHistoryService {
 
 			final var savedArchiveHistory = archiveAttachmentService.archiveAttachment(arende, handling, dokument, archiveHistory, municipalityId);
 
-			if (COMPLETED.equals(savedArchiveHistory.getArchiveStatus())
-				&& (savedArchiveHistory.getArchiveId() != null)
-				&& GEO.equals(getAttachmentCategory(handling.getTyp()))) {
-				// Send email to Lantmateriet with info about the archived attachment
-				final var arendeFastighetList = toArendeFastighetList(arende.getObjektLista().getAbstractArendeObjekt());
-
-				messagingIntegration.sendEmailToLantmateriet(
-					fbIntegration.getFastighet(arendeFastighetList).getFastighetsbeteckning(), savedArchiveHistory, municipalityId);
-			}
+			lantmaterietNotifier.notifyIfGeoDocument(arende, handling, savedArchiveHistory, municipalityId);
 		}
 	}
 

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import se.sundsvall.byggrarchiver.api.model.ArchiveHistoryResponse;
 import se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus;
 import se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
 import se.sundsvall.byggrarchiver.integration.arendeexport.ArendeExportIntegration;
 import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
 import se.sundsvall.byggrarchiver.integration.db.BatchHistoryRepository;
@@ -25,11 +26,17 @@ import se.sundsvall.byggrarchiver.integration.fb.FbIntegration;
 import se.sundsvall.byggrarchiver.integration.messaging.MessagingIntegration;
 import se.sundsvall.byggrarchiver.service.exceptions.ApplicationException;
 import se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper;
+import se.sundsvall.dept44.problem.ThrowableProblem;
 
+import static java.util.Optional.ofNullable;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED_FILE_TO_LARGE;
 import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.GEO;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.BYGGR_FETCH_ERROR;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.FILE_TOO_LARGE;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.METADATA_ERROR;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.UNKNOWN;
 import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.toArchiveHistory;
 import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.toArendeFastighetList;
 import static se.sundsvall.byggrarchiver.util.Constants.BYGGR_HANDELSETYP_ARKIV;
@@ -49,6 +56,8 @@ public class ArchiveHistoryService {
 
 	private final ArchiveAttachmentService archiveAttachmentService;
 
+	private final ArchiveFailureRecorder archiveFailureRecorder;
+
 	private final Integer maximumFileSize;
 
 	public ArchiveHistoryService(final BatchHistoryRepository batchHistoryRepository,
@@ -57,6 +66,7 @@ public class ArchiveHistoryService {
 		final MessagingIntegration messagingIntegration,
 		final ArchiveAttachmentService archiveAttachmentService,
 		final FbIntegration fbIntegration,
+		final ArchiveFailureRecorder archiveFailureRecorder,
 		@Value("${integration.archive.maximum-file-size}") final Integer maximumFileSize) {
 		this.batchHistoryRepository = batchHistoryRepository;
 		this.arendeExportIntegration = arendeExportIntegration;
@@ -64,6 +74,7 @@ public class ArchiveHistoryService {
 		this.messagingIntegration = messagingIntegration;
 		this.archiveAttachmentService = archiveAttachmentService;
 		this.fbIntegration = fbIntegration;
+		this.archiveFailureRecorder = archiveFailureRecorder;
 		this.maximumFileSize = maximumFileSize;
 	}
 
@@ -106,6 +117,7 @@ public class ArchiveHistoryService {
 						processHandlingList(handling, closedCase, batchHistory, municipalityId);
 					} catch (final ApplicationException e) {
 						LOG.error("Error when archiving document with ID: {} in combination with Case-ID: {}", handling.getDokument().getDokId(), closedCase.getDnr(), e);
+						archiveFailureRecorder.record(categoryForApplicationException(e), closedCase.getDnr(), handling.getDokument().getDokId(), handling.getDokument().getNamn(), batchHistory.getId(), municipalityId, "Archiving failed", e.getMessage());
 					}
 				}));
 		} while (batchFilter.getLowerExclusiveBound().isBefore(end));
@@ -181,6 +193,13 @@ public class ArchiveHistoryService {
 		}
 	}
 
+	private static FailureCategory categoryForApplicationException(final ApplicationException e) {
+		return ofNullable(e.getMessage())
+			.filter(message -> message.contains("marshal"))
+			.map(message -> METADATA_ERROR)
+			.orElse(UNKNOWN);
+	}
+
 	private void processHandlingList(final HandelseHandling handling, final Arende2 arende, final BatchHistory batchHistory, final String municipalityId) throws ApplicationException {
 		final ArchiveHistory newArchiveHistory;
 		final var docId = handling.getDokument().getDokId();
@@ -194,7 +213,15 @@ public class ArchiveHistoryService {
 		newArchiveHistory = toArchiveHistory(handling, batchHistory, arende.getDnr(), getAttachmentCategory(handling.getTyp()), NOT_COMPLETED, municipalityId);
 		archiveHistoryRepository.save(newArchiveHistory);
 		// Get documents from Byggr
-		final var dokumentList = arendeExportIntegration.getDocument(docId);
+		final List<Dokument> dokumentList;
+		try {
+			dokumentList = arendeExportIntegration.getDocument(docId);
+		} catch (final ThrowableProblem e) {
+			// A failed document fetch must not abort the whole batch - record it and continue with the next document
+			LOG.error("Error when fetching document with ID: {} in combination with Case-ID: {}", docId, arende.getDnr(), e);
+			archiveFailureRecorder.record(BYGGR_FETCH_ERROR, arende.getDnr(), docId, handling.getDokument().getNamn(), batchHistory.getId(), municipalityId, "ByggR getDocument failed", e.getMessage());
+			return;
+		}
 
 		// Archive documents
 		handleArchiving(dokumentList, arende, handling, newArchiveHistory, municipalityId);
@@ -215,6 +242,8 @@ public class ArchiveHistoryService {
 					NOT_COMPLETED_FILE_TO_LARGE);
 				archiveHistory.setArchiveStatus(NOT_COMPLETED_FILE_TO_LARGE);
 				archiveHistoryRepository.save(archiveHistory);
+				archiveFailureRecorder.record(FILE_TOO_LARGE, arende.getDnr(), dokument.getDokId(), dokument.getNamn(), archiveHistory.getBatchHistory().getId(), municipalityId, "File too large",
+					"actual=" + dokument.getFil().getFilBuffer().length + " bytes, max=" + maximumFileSize + " bytes");
 				continue;
 			}
 

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryService.java
@@ -5,9 +5,9 @@ import generated.se.sundsvall.arendeexport.ArendeBatch;
 import generated.se.sundsvall.arendeexport.BatchFilter;
 import generated.se.sundsvall.arendeexport.Dokument;
 import generated.se.sundsvall.arendeexport.HandelseHandling;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +57,8 @@ public class ArchiveHistoryService {
 
 	private final ArchiveFailureRecorder archiveFailureRecorder;
 
+	private final Clock clock;
+
 	private final Integer maximumFileSize;
 
 	public ArchiveHistoryService(final BatchHistoryRepository batchHistoryRepository,
@@ -66,6 +68,7 @@ public class ArchiveHistoryService {
 		final ArchiveAttachmentService archiveAttachmentService,
 		final FbIntegration fbIntegration,
 		final ArchiveFailureRecorder archiveFailureRecorder,
+		final Clock clock,
 		@Value("${integration.archive.maximum-file-size}") final Integer maximumFileSize) {
 		this.batchHistoryRepository = batchHistoryRepository;
 		this.arendeExportIntegration = arendeExportIntegration;
@@ -74,6 +77,7 @@ public class ArchiveHistoryService {
 		this.archiveAttachmentService = archiveAttachmentService;
 		this.fbIntegration = fbIntegration;
 		this.archiveFailureRecorder = archiveFailureRecorder;
+		this.clock = clock;
 		this.maximumFileSize = maximumFileSize;
 	}
 
@@ -153,12 +157,12 @@ public class ArchiveHistoryService {
 	}
 
 	private LocalDateTime getEnd(final LocalDate searchEnd) {
-		final var now = LocalDateTime.now(ZoneId.systemDefault());
+		final var now = LocalDateTime.now(clock);
 		if (searchEnd.isBefore(now.toLocalDate())) {
 			return searchEnd.atTime(23, 59, 59);
 		}
 
-		return LocalDateTime.now(ZoneId.systemDefault());
+		return now;
 	}
 
 	private void setLowerExclusiveBoundWithReturnedValue(final BatchFilter filter, final ArendeBatch arendeBatch) {

--- a/src/main/java/se/sundsvall/byggrarchiver/service/BatchCompletionService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/BatchCompletionService.java
@@ -1,0 +1,70 @@
+package se.sundsvall.byggrarchiver.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
+import se.sundsvall.byggrarchiver.integration.db.BatchHistoryRepository;
+import se.sundsvall.byggrarchiver.integration.db.model.BatchHistory;
+import se.sundsvall.byggrarchiver.integration.messaging.MessagingIntegration;
+
+import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
+import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED;
+
+@Service
+public class BatchCompletionService {
+
+	private static final Logger LOG = LoggerFactory.getLogger(BatchCompletionService.class);
+
+	private final BatchHistoryRepository batchHistoryRepository;
+	private final ArchiveHistoryRepository archiveHistoryRepository;
+	private final MessagingIntegration messagingIntegration;
+
+	public BatchCompletionService(final BatchHistoryRepository batchHistoryRepository, final ArchiveHistoryRepository archiveHistoryRepository, final MessagingIntegration messagingIntegration) {
+		this.batchHistoryRepository = batchHistoryRepository;
+		this.archiveHistoryRepository = archiveHistoryRepository;
+		this.messagingIntegration = messagingIntegration;
+	}
+
+	/**
+	 * Closes out a finished batch: marks it COMPLETED when all its archive histories are completed, otherwise sends a
+	 * status mail. Also retroactively promotes older NOT_COMPLETED batches whose documents have all since completed.
+	 */
+	public void completeBatch(final BatchHistory batchHistory, final String municipalityId) {
+		final var archiveHistoriesRelatedToBatch = archiveHistoryRepository.getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(batchHistory.getId(), municipalityId);
+		if (archiveHistoriesRelatedToBatch.stream().allMatch(archiveHistory -> COMPLETED.equals(archiveHistory.getArchiveStatus()))) {
+			// Persist that this batch is completed
+			batchHistory.setArchiveStatus(COMPLETED);
+			batchHistoryRepository.save(batchHistory);
+		} else {
+			// Send email when batch is not completed
+			messagingIntegration.sendStatusMail(archiveHistoriesRelatedToBatch, batchHistory.getId(), municipalityId);
+		}
+
+		LOG.info("Batch with ID: {} is {}", batchHistory.getId(), batchHistory.getArchiveStatus());
+		LOG.info("Batch with ID: {} has {} archive histories", batchHistory.getId(), archiveHistoriesRelatedToBatch.size());
+
+		updateStatusOfOldBatchHistories(municipalityId);
+	}
+
+	/**
+	 * Update the status of NOT_COMPLETED old batch histories to COMPLETED if all archive histories are COMPLETED
+	 */
+	private void updateStatusOfOldBatchHistories(final String municipalityId) {
+		final var notCompletedBatchHistories = batchHistoryRepository.findBatchHistoriesByArchiveStatusAndMunicipalityId(NOT_COMPLETED, municipalityId);
+
+		notCompletedBatchHistories.forEach(batchHistory -> {
+			final boolean allCompleted = archiveHistoryRepository.getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(batchHistory.getId(), municipalityId)
+				.stream()
+				.allMatch(archiveHistory -> COMPLETED.equals(archiveHistory.getArchiveStatus()));
+
+			if (allCompleted) {
+				batchHistory.setArchiveStatus(COMPLETED);
+				batchHistoryRepository.save(batchHistory);
+
+				LOG.info("Old batch with ID: {} was NOT_COMPLETED but is now COMPLETED", batchHistory.getId());
+			}
+		});
+	}
+
+}

--- a/src/main/java/se/sundsvall/byggrarchiver/service/LantmaterietNotifier.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/LantmaterietNotifier.java
@@ -1,0 +1,43 @@
+package se.sundsvall.byggrarchiver.service;
+
+import generated.se.sundsvall.arendeexport.Arende2;
+import generated.se.sundsvall.arendeexport.Handling;
+import org.springframework.stereotype.Service;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
+import se.sundsvall.byggrarchiver.integration.fb.FbIntegration;
+import se.sundsvall.byggrarchiver.integration.messaging.MessagingIntegration;
+import se.sundsvall.byggrarchiver.service.exceptions.ApplicationException;
+
+import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
+import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.GEO;
+import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.getAttachmentCategory;
+import static se.sundsvall.byggrarchiver.service.mapper.ArchiverMapper.toArendeFastighetList;
+
+@Service
+public class LantmaterietNotifier {
+
+	private final FbIntegration fbIntegration;
+	private final MessagingIntegration messagingIntegration;
+
+	public LantmaterietNotifier(final FbIntegration fbIntegration, final MessagingIntegration messagingIntegration) {
+		this.fbIntegration = fbIntegration;
+		this.messagingIntegration = messagingIntegration;
+	}
+
+	/**
+	 * Notifies Lantmäteriet about a successfully archived GEO (geoteknisk undersökning) document by emailing the
+	 * property designation. No-op for documents that are not GEO or were not actually archived.
+	 */
+	public void notifyIfGeoDocument(final Arende2 arende, final Handling handling, final ArchiveHistory archiveHistory, final String municipalityId) throws ApplicationException {
+		if (COMPLETED.equals(archiveHistory.getArchiveStatus())
+			&& (archiveHistory.getArchiveId() != null)
+			&& GEO.equals(getAttachmentCategory(handling.getTyp()))) {
+			// Send email to Lantmateriet with info about the archived attachment
+			final var arendeFastighetList = toArendeFastighetList(arende.getObjektLista().getAbstractArendeObjekt());
+
+			messagingIntegration.sendEmailToLantmateriet(
+				fbIntegration.getFastighet(arendeFastighetList).getFastighetsbeteckning(), archiveHistory, municipalityId);
+		}
+	}
+
+}

--- a/src/main/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapper.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapper.java
@@ -198,13 +198,15 @@ public final class ArchiverMapper {
 
 	public static ArchiveFailure toArchiveFailure(final FailureCategory failureCategory, final String caseId, final String documentId, final String documentName, final Long batchHistoryId, final String municipalityId, final String message,
 		final String detail) {
+		// All but detail map to varchar(255) columns - truncate so an over-long value from ByggR can never make the
+		// audit insert fail (and get silently swallowed by the recorder). detail is longtext, so it is left intact.
 		return ArchiveFailure.builder()
 			.withFailureCategory(failureCategory)
-			.withCaseId(caseId)
-			.withDocumentId(documentId)
-			.withDocumentName(documentName)
+			.withCaseId(truncate(caseId))
+			.withDocumentId(truncate(documentId))
+			.withDocumentName(truncate(documentName))
 			.withBatchHistoryId(batchHistoryId)
-			.withMunicipalityId(municipalityId)
+			.withMunicipalityId(truncate(municipalityId))
 			.withMessage(truncate(message))
 			.withDetail(detail)
 			.build();

--- a/src/main/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapper.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapper.java
@@ -20,11 +20,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import se.sundsvall.byggrarchiver.api.model.ArchiveFailureResponse;
 import se.sundsvall.byggrarchiver.api.model.ArchiveHistoryResponse;
 import se.sundsvall.byggrarchiver.api.model.BatchHistoryResponse;
 import se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus;
 import se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory;
 import se.sundsvall.byggrarchiver.api.model.enums.BatchTrigger;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveFailure;
 import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
 import se.sundsvall.byggrarchiver.integration.db.model.BatchHistory;
 import se.sundsvall.byggrarchiver.service.exceptions.ApplicationException;
@@ -191,6 +194,46 @@ public final class ArchiverMapper {
 			.withBatchTrigger(batchHistory.getBatchTrigger())
 			.withTimestamp(batchHistory.getTimestamp())
 			.build();
+	}
+
+	public static ArchiveFailure toArchiveFailure(final FailureCategory failureCategory, final String caseId, final String documentId, final String documentName, final Long batchHistoryId, final String municipalityId, final String message,
+		final String detail) {
+		return ArchiveFailure.builder()
+			.withFailureCategory(failureCategory)
+			.withCaseId(caseId)
+			.withDocumentId(documentId)
+			.withDocumentName(documentName)
+			.withBatchHistoryId(batchHistoryId)
+			.withMunicipalityId(municipalityId)
+			.withMessage(truncate(message))
+			.withDetail(detail)
+			.build();
+	}
+
+	public static ArchiveFailureResponse mapToArchiveFailureResponse(final ArchiveFailure archiveFailure) {
+		if (archiveFailure == null) {
+			return null;
+		}
+
+		return ArchiveFailureResponse.builder()
+			.withId(archiveFailure.getId())
+			.withBatchHistoryId(archiveFailure.getBatchHistoryId())
+			.withCaseId(archiveFailure.getCaseId())
+			.withDocumentId(archiveFailure.getDocumentId())
+			.withMunicipalityId(archiveFailure.getMunicipalityId())
+			.withDocumentName(archiveFailure.getDocumentName())
+			.withFailureCategory(archiveFailure.getFailureCategory())
+			.withMessage(archiveFailure.getMessage())
+			.withDetail(archiveFailure.getDetail())
+			.withTimestamp(archiveFailure.getTimestamp())
+			.build();
+	}
+
+	private static String truncate(final String message) {
+		return ofNullable(message)
+			.filter(value -> value.length() > 255)
+			.map(value -> value.substring(0, 255))
+			.orElse(message);
 	}
 
 	public static BatchHistory createBatchHistory(final LocalDate actualStart, final LocalDate end, final BatchTrigger batchTrigger, final ArchiveStatus archiveStatus, final String municipalityId) {

--- a/src/main/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapper.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapper.java
@@ -196,17 +196,16 @@ public final class ArchiverMapper {
 			.build();
 	}
 
-	public static ArchiveFailure toArchiveFailure(final FailureCategory failureCategory, final String caseId, final String documentId, final String documentName, final Long batchHistoryId, final String municipalityId, final String message,
-		final String detail) {
+	public static ArchiveFailure toArchiveFailure(final FailureCategory failureCategory, final ArchiveHistory archiveHistory, final String message, final String detail) {
 		// All but detail map to varchar(255) columns - truncate so an over-long value from ByggR can never make the
 		// audit insert fail (and get silently swallowed by the recorder). detail is longtext, so it is left intact.
 		return ArchiveFailure.builder()
 			.withFailureCategory(failureCategory)
-			.withCaseId(truncate(caseId))
-			.withDocumentId(truncate(documentId))
-			.withDocumentName(truncate(documentName))
-			.withBatchHistoryId(batchHistoryId)
-			.withMunicipalityId(truncate(municipalityId))
+			.withCaseId(truncate(archiveHistory.getCaseId()))
+			.withDocumentId(truncate(archiveHistory.getDocumentId()))
+			.withDocumentName(truncate(archiveHistory.getDocumentName()))
+			.withBatchHistoryId(ofNullable(archiveHistory.getBatchHistory()).map(BatchHistory::getId).orElse(null))
+			.withMunicipalityId(truncate(archiveHistory.getMunicipalityId()))
 			.withMessage(truncate(message))
 			.withDetail(detail)
 			.build();

--- a/src/main/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapper.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapper.java
@@ -17,6 +17,7 @@ import generated.se.sundsvall.bygglov.ExtraID;
 import generated.se.sundsvall.bygglov.StatusArande;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -66,15 +67,15 @@ public final class ArchiverMapper {
 	}
 
 	static boolean isAfter1992(final LocalDate ankomstDatum) {
-		return ankomstDatum.isAfter(LocalDate.of(1992, 12, 31));
+		return ankomstDatum.isAfter(LocalDate.of(1992, Month.DECEMBER, 31));
 	}
 
 	static boolean isAfter2016(final LocalDate ankomstDatum) {
-		return ankomstDatum.isAfter(LocalDate.of(2016, 12, 31));
+		return ankomstDatum.isAfter(LocalDate.of(2016, Month.DECEMBER, 31));
 	}
 
 	static boolean isBefore1993(final LocalDate ankomstDatum) {
-		return ankomstDatum.isBefore(LocalDate.of(1993, 1, 1));
+		return ankomstDatum.isBefore(LocalDate.of(1993, Month.JANUARY, 1));
 	}
 
 	public static ArkivbildarStrukturTyp toArkivbildarStruktur(final LocalDate ankomstDatum) {

--- a/src/main/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapper.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapper.java
@@ -119,7 +119,7 @@ public final class ArchiverMapper {
 		return date.format(ISO_DATE);
 	}
 
-	public static AttachmentCategory toAttachmentCategory(final String handlingsTyp) {
+	public static AttachmentCategory getAttachmentCategory(final String handlingsTyp) {
 		try {
 			return AttachmentCategory.fromCode(handlingsTyp);
 		} catch (final IllegalArgumentException e) {
@@ -277,7 +277,7 @@ public final class ArchiverMapper {
 			.withBilaga(toBilaga(document));
 
 		if (handling.getTyp() != null) {
-			final var attachmentCategory = toAttachmentCategory(handling.getTyp());
+			final var attachmentCategory = getAttachmentCategory(handling.getTyp());
 			arkivobjektHandling.setHandlingstyp(attachmentCategory.getArchiveClassification());
 			arkivobjektHandling.setRubrik(attachmentCategory.getDescription());
 		}

--- a/src/main/java/se/sundsvall/byggrarchiver/service/scheduler/ArchiverScheduler.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/scheduler/ArchiverScheduler.java
@@ -1,7 +1,7 @@
 package se.sundsvall.byggrarchiver.service.scheduler;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -16,10 +16,12 @@ public class ArchiverScheduler {
 
 	private final ByggrArchiverService byggrArchiverService;
 	private final SchedulerProperties schedulerProperties;
+	private final Clock clock;
 
-	public ArchiverScheduler(final ByggrArchiverService byggrArchiverService, final SchedulerProperties schedulerProperties) {
+	public ArchiverScheduler(final ByggrArchiverService byggrArchiverService, final SchedulerProperties schedulerProperties, final Clock clock) {
 		this.byggrArchiverService = byggrArchiverService;
 		this.schedulerProperties = schedulerProperties;
+		this.clock = clock;
 
 		if ("-".equals(schedulerProperties.cron().expression())) {
 			LOG.info("ArchiverScheduler is DISABLED");
@@ -33,7 +35,7 @@ public class ArchiverScheduler {
 		lockAtMostFor = "${scheduler.shedlock-lock-at-most-for}",
 		maximumExecutionTime = "${scheduler.maximum-execution-time}")
 	public void archive() {
-		final var now = LocalDateTime.now(ZoneId.systemDefault());
+		final var now = LocalDateTime.now(clock);
 
 		LOG.info("Running archiving on schedule. Timestamp: {}", now);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,8 +36,9 @@ logbook:
     jsonPath:
       - key: '$..file'
         value: '[base64]'
-  logs:
-    maxBodySizeToLog: 1000000
+  # NOTE: do NOT set logbook.logs.maxBodySizeToLog. dept44 registers truncate() before the body filters, so any body
+  # larger than the limit is cut into malformed XML/JSON and the filters below silently stop redacting (the filBuffer
+  # base64 / file contents then leak into the logs). The filters already shrink the logged payload by redacting binary.
 scheduler:
   name: archive
   cron:

--- a/src/main/resources/db/migration/V1_3__add_archive_failure.sql
+++ b/src/main/resources/db/migration/V1_3__add_archive_failure.sql
@@ -1,0 +1,22 @@
+create table archive_failure (
+    id bigint not null auto_increment,
+    batch_history_id bigint not null,
+    timestamp datetime(6) not null,
+    case_id varchar(255) not null,
+    document_id varchar(255),
+    municipality_id varchar(255),
+    document_name varchar(255),
+    message varchar(255),
+    detail longtext,
+    failure_category varchar(255) not null,
+    primary key (id)
+) engine=InnoDB;
+
+create index archive_failure_batch_history_id_idx
+    on archive_failure (batch_history_id);
+
+create index archive_failure_municipality_id_idx
+    on archive_failure (municipality_id);
+
+create index archive_failure_failure_category_idx
+    on archive_failure (failure_category);

--- a/src/main/resources/db/migration/V1_3__add_archive_failure.sql
+++ b/src/main/resources/db/migration/V1_3__add_archive_failure.sql
@@ -2,7 +2,7 @@ create table archive_failure (
     id bigint not null auto_increment,
     batch_history_id bigint not null,
     timestamp datetime(6) not null,
-    case_id varchar(255) not null,
+    case_id varchar(255),
     document_id varchar(255),
     municipality_id varchar(255),
     document_name varchar(255),

--- a/src/test/java/se/sundsvall/byggrarchiver/api/ByggrArchiverResourceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/api/ByggrArchiverResourceTest.java
@@ -2,6 +2,7 @@ package se.sundsvall.byggrarchiver.api;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +45,10 @@ import static se.sundsvall.byggrarchiver.testutils.TestUtil.randomLong;
 class ByggrArchiverResourceTest {
 
 	private static final String MUNICIPALITY_ID = "2281";
+
+	private static final LocalDate DATE = LocalDate.of(2024, Month.JANUARY, 16);
+
+	private static final LocalDateTime DATE_TIME = LocalDateTime.of(2024, Month.JANUARY, 16, 12, 0);
 
 	private static final String BATCH_PATH = "/{municipalityId}/batch-jobs";
 
@@ -124,8 +129,8 @@ class ByggrArchiverResourceTest {
 	@Test
 	void postBatchJob() {
 		final var batchJob = BatchJob.builder()
-			.withStart(LocalDate.now().minusDays(3))
-			.withEnd(LocalDate.now())
+			.withStart(DATE.minusDays(3))
+			.withEnd(DATE)
 			.build();
 
 		final var batchHistory = BatchHistoryResponse.builder()
@@ -134,7 +139,7 @@ class ByggrArchiverResourceTest {
 			.withArchiveStatus(ArchiveStatus.COMPLETED)
 			.withStart(batchJob.getStart())
 			.withEnd(batchJob.getEnd())
-			.withTimestamp(LocalDateTime.now())
+			.withTimestamp(DATE_TIME)
 			.build();
 
 		when(mockByggrArchiverService.runBatch(any(LocalDate.class), any(LocalDate.class), any(BatchTrigger.class), eq(MUNICIPALITY_ID)))
@@ -172,7 +177,7 @@ class ByggrArchiverResourceTest {
 			.withFailureCategory(FailureCategory.ARCHIVE_ERROR)
 			.withMessage("Archive request failed")
 			.withDetail("detail")
-			.withTimestamp(LocalDateTime.now())
+			.withTimestamp(DATE_TIME)
 			.build();
 
 		when(mockArchiveFailureRepository.findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(eq(5L), eq(MUNICIPALITY_ID), eq(FailureCategory.ARCHIVE_ERROR)))

--- a/src/test/java/se/sundsvall/byggrarchiver/api/ByggrArchiverResourceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/api/ByggrArchiverResourceTest.java
@@ -12,13 +12,17 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import se.sundsvall.byggrarchiver.Application;
+import se.sundsvall.byggrarchiver.api.model.ArchiveFailureResponse;
 import se.sundsvall.byggrarchiver.api.model.ArchiveHistoryResponse;
 import se.sundsvall.byggrarchiver.api.model.BatchHistoryResponse;
 import se.sundsvall.byggrarchiver.api.model.BatchJob;
 import se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus;
 import se.sundsvall.byggrarchiver.api.model.enums.BatchTrigger;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+import se.sundsvall.byggrarchiver.integration.db.ArchiveFailureRepository;
 import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
 import se.sundsvall.byggrarchiver.integration.db.BatchHistoryRepository;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveFailure;
 import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
 import se.sundsvall.byggrarchiver.integration.db.model.BatchHistory;
 import se.sundsvall.byggrarchiver.service.ByggrArchiverService;
@@ -53,6 +57,9 @@ class ByggrArchiverResourceTest {
 
 	@MockitoBean
 	private BatchHistoryRepository mockBatchHistoryRepository;
+
+	@MockitoBean
+	private ArchiveFailureRepository mockArchiveFailureRepository;
 
 	@Autowired
 	private ByggrArchiverResource resource;
@@ -151,6 +158,53 @@ class ByggrArchiverResourceTest {
 			.exchange()
 			.expectStatus().isOk()
 			.expectBody(BatchHistory.class);
+	}
+
+	@Test
+	void getFallout() {
+		final var archiveFailure = ArchiveFailure.builder()
+			.withId(1L)
+			.withBatchHistoryId(5L)
+			.withCaseId("BYGG 2021-1")
+			.withDocumentId("doc-1")
+			.withMunicipalityId(MUNICIPALITY_ID)
+			.withDocumentName("documentName")
+			.withFailureCategory(FailureCategory.ARCHIVE_ERROR)
+			.withMessage("Archive request failed")
+			.withDetail("detail")
+			.withTimestamp(LocalDateTime.now())
+			.build();
+
+		when(mockArchiveFailureRepository.findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(eq(5L), eq(MUNICIPALITY_ID), eq(FailureCategory.ARCHIVE_ERROR)))
+			.thenReturn(List.of(archiveFailure));
+
+		final var result = webTestClient.get()
+			.uri(BATCH_PATH + "/{batchHistoryId}/fallout?category={category}", MUNICIPALITY_ID, 5L, FailureCategory.ARCHIVE_ERROR)
+			.exchange()
+			.expectStatus().isOk()
+			.expectBodyList(ArchiveFailureResponse.class)
+			.returnResult()
+			.getResponseBody();
+
+		assertThat(result).hasSize(1);
+		assertThat(result.getFirst().getFailureCategory()).isEqualTo(FailureCategory.ARCHIVE_ERROR);
+		assertThat(result.getFirst().getCaseId()).isEqualTo("BYGG 2021-1");
+	}
+
+	@Test
+	void getFalloutEmpty() {
+		when(mockArchiveFailureRepository.findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(anyLong(), eq(MUNICIPALITY_ID), any()))
+			.thenReturn(List.of());
+
+		final var result = webTestClient.get()
+			.uri(BATCH_PATH + "/{batchHistoryId}/fallout", MUNICIPALITY_ID, randomLong())
+			.exchange()
+			.expectStatus().isOk()
+			.expectBodyList(ArchiveFailureResponse.class)
+			.returnResult()
+			.getResponseBody();
+
+		assertThat(result).isEmpty();
 	}
 
 }

--- a/src/test/java/se/sundsvall/byggrarchiver/api/model/ArchiveFailureResponseTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/api/model/ArchiveFailureResponseTest.java
@@ -1,0 +1,84 @@
+package se.sundsvall.byggrarchiver.api.model;
+
+import java.time.LocalDateTime;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
+import static com.google.code.beanmatchers.BeanMatchers.registerValueGenerator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static se.sundsvall.byggrarchiver.testutils.TestUtil.randomInt;
+
+class ArchiveFailureResponseTest {
+
+	@BeforeAll
+	static void setup() {
+		registerValueGenerator(() -> LocalDateTime.now().plusDays(randomInt()), LocalDateTime.class);
+	}
+
+	@Test
+	void testBean() {
+		MatcherAssert.assertThat(ArchiveFailureResponse.class, allOf(
+			hasValidBeanConstructor(),
+			hasValidGettersAndSetters(),
+			hasValidBeanHashCode(),
+			hasValidBeanEquals(),
+			hasValidBeanToString()));
+	}
+
+	@Test
+	void builder() {
+		// Arrange
+		final var id = 1L;
+		final var batchHistoryId = 2L;
+		final var caseId = "caseId";
+		final var documentId = "documentId";
+		final var municipalityId = "2281";
+		final var documentName = "documentName";
+		final var failureCategory = FailureCategory.BYGGR_FETCH_ERROR;
+		final var message = "message";
+		final var detail = "detail";
+		final var timestamp = LocalDateTime.now();
+
+		// Act
+		final var archiveFailureResponse = ArchiveFailureResponse.builder()
+			.withId(id)
+			.withBatchHistoryId(batchHistoryId)
+			.withCaseId(caseId)
+			.withDocumentId(documentId)
+			.withMunicipalityId(municipalityId)
+			.withDocumentName(documentName)
+			.withFailureCategory(failureCategory)
+			.withMessage(message)
+			.withDetail(detail)
+			.withTimestamp(timestamp)
+			.build();
+
+		// Assert
+		assertThat(archiveFailureResponse).isNotNull().hasNoNullFieldsOrProperties();
+		assertThat(archiveFailureResponse.getId()).isEqualTo(id);
+		assertThat(archiveFailureResponse.getBatchHistoryId()).isEqualTo(batchHistoryId);
+		assertThat(archiveFailureResponse.getCaseId()).isEqualTo(caseId);
+		assertThat(archiveFailureResponse.getDocumentId()).isEqualTo(documentId);
+		assertThat(archiveFailureResponse.getMunicipalityId()).isEqualTo(municipalityId);
+		assertThat(archiveFailureResponse.getDocumentName()).isEqualTo(documentName);
+		assertThat(archiveFailureResponse.getFailureCategory()).isEqualTo(failureCategory);
+		assertThat(archiveFailureResponse.getMessage()).isEqualTo(message);
+		assertThat(archiveFailureResponse.getDetail()).isEqualTo(detail);
+		assertThat(archiveFailureResponse.getTimestamp()).isEqualTo(timestamp);
+	}
+
+	@Test
+	void testNoDirtOnCreatedBean() {
+		assertThat(ArchiveFailureResponse.builder().build()).hasAllNullFieldsOrProperties();
+		assertThat(new ArchiveFailureResponse()).hasAllNullFieldsOrProperties();
+	}
+
+}

--- a/src/test/java/se/sundsvall/byggrarchiver/api/model/ArchiveFailureResponseTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/api/model/ArchiveFailureResponseTest.java
@@ -1,6 +1,7 @@
 package se.sundsvall.byggrarchiver.api.model;
 
 import java.time.LocalDateTime;
+import java.time.Month;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ class ArchiveFailureResponseTest {
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> LocalDateTime.now().plusDays(randomInt()), LocalDateTime.class);
+		registerValueGenerator(() -> LocalDateTime.of(2000, Month.JANUARY, 1, 0, 0).plusDays(randomInt()), LocalDateTime.class);
 	}
 
 	@Test
@@ -45,7 +46,7 @@ class ArchiveFailureResponseTest {
 		final var failureCategory = FailureCategory.BYGGR_FETCH_ERROR;
 		final var message = "message";
 		final var detail = "detail";
-		final var timestamp = LocalDateTime.now();
+		final var timestamp = LocalDateTime.of(2024, Month.JANUARY, 16, 12, 0);
 
 		// Act
 		final var archiveFailureResponse = ArchiveFailureResponse.builder()

--- a/src/test/java/se/sundsvall/byggrarchiver/api/model/ArchiveHistoryResponseTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/api/model/ArchiveHistoryResponseTest.java
@@ -2,6 +2,7 @@ package se.sundsvall.byggrarchiver.api.model;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -21,8 +22,8 @@ class ArchiveHistoryResponseTest {
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> LocalDate.now().plusDays(randomInt()), LocalDate.class);
-		registerValueGenerator(() -> LocalDateTime.now().plusDays(randomInt()), LocalDateTime.class);
+		registerValueGenerator(() -> LocalDate.of(2000, Month.JANUARY, 1).plusDays(randomInt()), LocalDate.class);
+		registerValueGenerator(() -> LocalDateTime.of(2000, Month.JANUARY, 1, 0, 0).plusDays(randomInt()), LocalDateTime.class);
 	}
 
 	@Test
@@ -45,7 +46,7 @@ class ArchiveHistoryResponseTest {
 		final var archiveId = "archiveId";
 		final var archiveUrl = "archiveUrl";
 		final var archiveStatus = ArchiveStatus.COMPLETED;
-		final var timestamp = LocalDateTime.now();
+		final var timestamp = LocalDateTime.of(2024, Month.JANUARY, 16, 12, 0);
 		final var batchHistory = new BatchHistoryResponse();
 
 		// Act

--- a/src/test/java/se/sundsvall/byggrarchiver/api/model/BatchHistoryResponseTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/api/model/BatchHistoryResponseTest.java
@@ -2,6 +2,7 @@ package se.sundsvall.byggrarchiver.api.model;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -22,8 +23,8 @@ class BatchHistoryResponseTest {
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> LocalDate.now().plusDays(randomInt()), LocalDate.class);
-		registerValueGenerator(() -> LocalDateTime.now().plusDays(randomInt()), LocalDateTime.class);
+		registerValueGenerator(() -> LocalDate.of(2000, Month.JANUARY, 1).plusDays(randomInt()), LocalDate.class);
+		registerValueGenerator(() -> LocalDateTime.of(2000, Month.JANUARY, 1, 0, 0).plusDays(randomInt()), LocalDateTime.class);
 	}
 
 	@Test
@@ -39,11 +40,11 @@ class BatchHistoryResponseTest {
 	void builder() {
 		// Arrange
 		final var id = 1L;
-		final var start = LocalDate.now();
-		final var end = LocalDate.now();
+		final var start = LocalDate.of(2024, Month.JANUARY, 16);
+		final var end = LocalDate.of(2024, Month.JANUARY, 16);
 		final var archiveStatus = ArchiveStatus.COMPLETED;
 		final var batchTrigger = BatchTrigger.MANUAL;
-		final var timestamp = LocalDateTime.now();
+		final var timestamp = LocalDateTime.of(2024, Month.JANUARY, 16, 12, 0);
 
 		// Act
 		final var batchHistoryResponse = BatchHistoryResponse.builder()

--- a/src/test/java/se/sundsvall/byggrarchiver/api/model/BatchJobTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/api/model/BatchJobTest.java
@@ -1,6 +1,7 @@
 package se.sundsvall.byggrarchiver.api.model;
 
 import java.time.LocalDate;
+import java.time.Month;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +19,7 @@ class BatchJobTest {
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> LocalDate.now().plusDays(randomInt()), LocalDate.class);
+		registerValueGenerator(() -> LocalDate.of(2000, Month.JANUARY, 1).plusDays(randomInt()), LocalDate.class);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/byggrarchiver/api/validation/StartBeforeEndTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/api/validation/StartBeforeEndTest.java
@@ -2,6 +2,7 @@ package se.sundsvall.byggrarchiver.api.validation;
 
 import jakarta.validation.ConstraintValidatorContext;
 import java.time.LocalDate;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -15,6 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(MockitoExtension.class)
 class StartBeforeEndTest {
 
+	private static final LocalDate DATE = LocalDate.of(2024, Month.JANUARY, 16);
+
 	@Mock
 	private ConstraintValidatorContext constraintValidatorContextMock;
 
@@ -24,8 +27,8 @@ class StartBeforeEndTest {
 	@Test
 	void valid() {
 		var batchJob = BatchJob.builder()
-			.withStart(LocalDate.now().minusDays(3))
-			.withEnd(LocalDate.now())
+			.withStart(DATE.minusDays(3))
+			.withEnd(DATE)
 			.build();
 
 		assertThat(validator.isValid(batchJob, constraintValidatorContextMock)).isTrue();
@@ -34,8 +37,8 @@ class StartBeforeEndTest {
 	@Test
 	void validSameDate() {
 		var batchJob = BatchJob.builder()
-			.withStart(LocalDate.now())
-			.withEnd(LocalDate.now())
+			.withStart(DATE)
+			.withEnd(DATE)
 			.build();
 
 		assertThat(validator.isValid(batchJob, constraintValidatorContextMock)).isTrue();
@@ -44,8 +47,8 @@ class StartBeforeEndTest {
 	@Test
 	void invalid() {
 		var batchJob = BatchJob.builder()
-			.withStart(LocalDate.now())
-			.withEnd(LocalDate.now().minusDays(3))
+			.withStart(DATE)
+			.withEnd(DATE.minusDays(3))
 			.build();
 
 		assertThat(validator.isValid(batchJob, constraintValidatorContextMock)).isFalse();
@@ -54,13 +57,13 @@ class StartBeforeEndTest {
 	@Test
 	void nullValue() {
 		var batchJob = BatchJob.builder()
-			.withEnd(LocalDate.now().minusDays(3))
+			.withEnd(DATE.minusDays(3))
 			.build();
 
 		assertThat(validator.isValid(batchJob, constraintValidatorContextMock)).isTrue();
 
 		var batchJob2 = BatchJob.builder()
-			.withStart(LocalDate.now().minusDays(3))
+			.withStart(DATE.minusDays(3))
 			.build();
 
 		assertThat(validator.isValid(batchJob2, constraintValidatorContextMock)).isTrue();

--- a/src/test/java/se/sundsvall/byggrarchiver/integration/db/ArchiveFailureRepositoryTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/integration/db/ArchiveFailureRepositoryTest.java
@@ -1,0 +1,68 @@
+package se.sundsvall.byggrarchiver.integration.db;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.test.context.ActiveProfiles;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveFailure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace.NONE;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.ARCHIVE_ERROR;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.FILE_TOO_LARGE;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+@ActiveProfiles("junit")
+class ArchiveFailureRepositoryTest {
+
+	private static final String MUNICIPALITY_ID = "2281";
+
+	@Autowired
+	private ArchiveFailureRepository archiveFailureRepository;
+
+	@Test
+	void persistsAndFiltersByBatchMunicipalityAndOptionalCategory() {
+		archiveFailureRepository.save(failure(1L, MUNICIPALITY_ID, ARCHIVE_ERROR, "case-1"));
+		// caseId is null here - the insert must still succeed (no NOT NULL constraint)
+		archiveFailureRepository.save(failure(1L, MUNICIPALITY_ID, FILE_TOO_LARGE, null));
+		archiveFailureRepository.save(failure(2L, MUNICIPALITY_ID, ARCHIVE_ERROR, "case-other-batch"));
+		archiveFailureRepository.save(failure(1L, "2282", ARCHIVE_ERROR, "case-other-muni"));
+
+		// No category -> all failures for batch 1 / municipality 2281
+		final var all = archiveFailureRepository.findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(1L, MUNICIPALITY_ID, null);
+		assertThat(all)
+			.hasSize(2)
+			.extracting(ArchiveFailure::getFailureCategory)
+			.containsExactlyInAnyOrder(ARCHIVE_ERROR, FILE_TOO_LARGE);
+		assertThat(all).allSatisfy(failure -> {
+			assertThat(failure.getId()).isNotNull();
+			assertThat(failure.getTimestamp()).isNotNull();
+		});
+
+		// Category filter applied
+		final var filtered = archiveFailureRepository.findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(1L, MUNICIPALITY_ID, ARCHIVE_ERROR);
+		assertThat(filtered)
+			.singleElement()
+			.satisfies(failure -> {
+				assertThat(failure.getFailureCategory()).isEqualTo(ARCHIVE_ERROR);
+				assertThat(failure.getCaseId()).isEqualTo("case-1");
+			});
+	}
+
+	private static ArchiveFailure failure(final Long batchHistoryId, final String municipalityId, final FailureCategory failureCategory, final String caseId) {
+		return ArchiveFailure.builder()
+			.withBatchHistoryId(batchHistoryId)
+			.withMunicipalityId(municipalityId)
+			.withFailureCategory(failureCategory)
+			.withCaseId(caseId)
+			.withDocumentId("doc")
+			.withDocumentName("name")
+			.withMessage("message")
+			.withDetail("detail")
+			.build();
+	}
+
+}

--- a/src/test/java/se/sundsvall/byggrarchiver/integration/db/model/ArchiveFailureTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/integration/db/model/ArchiveFailureTest.java
@@ -1,0 +1,84 @@
+package se.sundsvall.byggrarchiver.integration.db.model;
+
+import java.time.LocalDateTime;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
+import static com.google.code.beanmatchers.BeanMatchers.registerValueGenerator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.AllOf.allOf;
+import static se.sundsvall.byggrarchiver.testutils.TestUtil.randomInt;
+
+class ArchiveFailureTest {
+
+	@BeforeAll
+	static void setup() {
+		registerValueGenerator(() -> LocalDateTime.now().plusDays(randomInt()), LocalDateTime.class);
+	}
+
+	@Test
+	void testBean() {
+		MatcherAssert.assertThat(ArchiveFailure.class, allOf(
+			hasValidBeanConstructor(),
+			hasValidGettersAndSetters(),
+			hasValidBeanHashCode(),
+			hasValidBeanEquals(),
+			hasValidBeanToString()));
+	}
+
+	@Test
+	void builder() {
+		// Arrange
+		final var id = 1L;
+		final var batchHistoryId = 2L;
+		final var caseId = "caseId";
+		final var documentId = "documentId";
+		final var municipalityId = "2281";
+		final var documentName = "documentName";
+		final var failureCategory = FailureCategory.ARCHIVE_ERROR;
+		final var message = "message";
+		final var detail = "detail";
+		final var timestamp = LocalDateTime.now();
+
+		// Act
+		final var archiveFailure = ArchiveFailure.builder()
+			.withId(id)
+			.withBatchHistoryId(batchHistoryId)
+			.withCaseId(caseId)
+			.withDocumentId(documentId)
+			.withMunicipalityId(municipalityId)
+			.withDocumentName(documentName)
+			.withFailureCategory(failureCategory)
+			.withMessage(message)
+			.withDetail(detail)
+			.withTimestamp(timestamp)
+			.build();
+
+		// Assert
+		assertThat(archiveFailure).isNotNull().hasNoNullFieldsOrProperties();
+		assertThat(archiveFailure.getId()).isEqualTo(id);
+		assertThat(archiveFailure.getBatchHistoryId()).isEqualTo(batchHistoryId);
+		assertThat(archiveFailure.getCaseId()).isEqualTo(caseId);
+		assertThat(archiveFailure.getDocumentId()).isEqualTo(documentId);
+		assertThat(archiveFailure.getMunicipalityId()).isEqualTo(municipalityId);
+		assertThat(archiveFailure.getDocumentName()).isEqualTo(documentName);
+		assertThat(archiveFailure.getFailureCategory()).isEqualTo(failureCategory);
+		assertThat(archiveFailure.getMessage()).isEqualTo(message);
+		assertThat(archiveFailure.getDetail()).isEqualTo(detail);
+		assertThat(archiveFailure.getTimestamp()).isEqualTo(timestamp);
+	}
+
+	@Test
+	void testNoDirtOnCreatedBean() {
+		assertThat(ArchiveFailure.builder().build()).hasAllNullFieldsOrProperties();
+		assertThat(new ArchiveFailure()).hasAllNullFieldsOrProperties();
+	}
+
+}

--- a/src/test/java/se/sundsvall/byggrarchiver/integration/db/model/ArchiveFailureTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/integration/db/model/ArchiveFailureTest.java
@@ -1,6 +1,7 @@
 package se.sundsvall.byggrarchiver.integration.db.model;
 
 import java.time.LocalDateTime;
+import java.time.Month;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ class ArchiveFailureTest {
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> LocalDateTime.now().plusDays(randomInt()), LocalDateTime.class);
+		registerValueGenerator(() -> LocalDateTime.of(2000, Month.JANUARY, 1, 0, 0).plusDays(randomInt()), LocalDateTime.class);
 	}
 
 	@Test
@@ -45,7 +46,7 @@ class ArchiveFailureTest {
 		final var failureCategory = FailureCategory.ARCHIVE_ERROR;
 		final var message = "message";
 		final var detail = "detail";
-		final var timestamp = LocalDateTime.now();
+		final var timestamp = LocalDateTime.of(2024, Month.JANUARY, 16, 12, 0);
 
 		// Act
 		final var archiveFailure = ArchiveFailure.builder()

--- a/src/test/java/se/sundsvall/byggrarchiver/integration/db/model/ArchiveHistoryTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/integration/db/model/ArchiveHistoryTest.java
@@ -1,6 +1,7 @@
 package se.sundsvall.byggrarchiver.integration.db.model;
 
 import java.time.LocalDateTime;
+import java.time.Month;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ class ArchiveHistoryTest {
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> LocalDateTime.now().plusDays(randomInt()), LocalDateTime.class);
+		registerValueGenerator(() -> LocalDateTime.of(2000, Month.JANUARY, 1, 0, 0).plusDays(randomInt()), LocalDateTime.class);
 	}
 
 	@Test
@@ -43,7 +44,7 @@ class ArchiveHistoryTest {
 		final var archiveId = "archiveId";
 		final var archiveUrl = "archiveUrl";
 		final var archiveStatus = ArchiveStatus.COMPLETED;
-		final var timestamp = LocalDateTime.now();
+		final var timestamp = LocalDateTime.of(2024, Month.JANUARY, 16, 12, 0);
 		final var batchHistory = new BatchHistory();
 		final var municipalityId = "municipalityId";
 

--- a/src/test/java/se/sundsvall/byggrarchiver/integration/db/model/BatchHistoryTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/integration/db/model/BatchHistoryTest.java
@@ -2,6 +2,7 @@ package se.sundsvall.byggrarchiver.integration.db.model;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -22,8 +23,8 @@ class BatchHistoryTest {
 
 	@BeforeAll
 	static void setup() {
-		registerValueGenerator(() -> LocalDateTime.now().plusDays(randomInt()), LocalDateTime.class);
-		registerValueGenerator(() -> LocalDate.now().plusDays(randomInt()), LocalDate.class);
+		registerValueGenerator(() -> LocalDateTime.of(2000, Month.JANUARY, 1, 0, 0).plusDays(randomInt()), LocalDateTime.class);
+		registerValueGenerator(() -> LocalDate.of(2000, Month.JANUARY, 1).plusDays(randomInt()), LocalDate.class);
 	}
 
 	@Test
@@ -40,11 +41,11 @@ class BatchHistoryTest {
 	void builder() {
 		// Arrange
 		final var id = 1L;
-		final var start = LocalDate.now();
-		final var end = LocalDate.now();
+		final var start = LocalDate.of(2024, Month.JANUARY, 16);
+		final var end = LocalDate.of(2024, Month.JANUARY, 16);
 		final var archiveStatus = ArchiveStatus.COMPLETED;
 		final var batchTrigger = BatchTrigger.MANUAL;
-		final var timestamp = LocalDateTime.now();
+		final var timestamp = LocalDateTime.of(2024, Month.JANUARY, 16, 12, 0);
 		final var municipalityId = "2281";
 
 		// Act

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentServiceTest.java
@@ -263,7 +263,7 @@ class ArchiveAttachmentServiceTest {
 		verify(archiveHistoryRepositoryMock).save(any(ArchiveHistory.class));
 		verify(archiveIntegrationMock).archive(any(ByggRArchiveRequest.class), eq(MUNICIPALITY_ID));
 		verify(fastighetService).getFastighet(any());
-		verify(archiveFailureRecorderMock).record(eq(FailureCategory.ARCHIVE_ERROR), any(), any(), any(), any(), eq(MUNICIPALITY_ID), eq("No archive id returned"), any());
+		verify(archiveFailureRecorderMock).recordFailure(eq(FailureCategory.ARCHIVE_ERROR), eq(archiveHistory), eq("No archive id returned"), any());
 	}
 
 	@Test
@@ -291,7 +291,7 @@ class ArchiveAttachmentServiceTest {
 		verify(archiveIntegrationMock).archive(any(ByggRArchiveRequest.class), eq(MUNICIPALITY_ID));
 		verify(fastighetService).getFastighet(any());
 		verify(messagingIntegrationMock).sendExtensionErrorEmail(archiveHistory, MUNICIPALITY_ID);
-		verify(archiveFailureRecorderMock).record(eq(FailureCategory.ARCHIVE_REJECTED_FORMAT), any(), any(), any(), any(), eq(MUNICIPALITY_ID), eq("Archive rejected file format"), any());
+		verify(archiveFailureRecorderMock).recordFailure(eq(FailureCategory.ARCHIVE_REJECTED_FORMAT), eq(archiveHistory), eq("Archive rejected file format"), any());
 	}
 
 	/**

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentServiceTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus;
 import se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
 import se.sundsvall.byggrarchiver.configuration.LongTermArchiveProperties;
 import se.sundsvall.byggrarchiver.integration.archive.ArchiveIntegration;
 import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
@@ -70,6 +71,9 @@ class ArchiveAttachmentServiceTest {
 
 	@Mock
 	private FbIntegration fastighetService;
+
+	@Mock
+	private ArchiveFailureRecorder archiveFailureRecorderMock;
 
 	@Captor
 	private ArgumentCaptor<ByggRArchiveRequest> byggRArchiveRequestCaptor;
@@ -259,6 +263,7 @@ class ArchiveAttachmentServiceTest {
 		verify(archiveHistoryRepositoryMock).save(any(ArchiveHistory.class));
 		verify(archiveIntegrationMock).archive(any(ByggRArchiveRequest.class), eq(MUNICIPALITY_ID));
 		verify(fastighetService).getFastighet(any());
+		verify(archiveFailureRecorderMock).record(eq(FailureCategory.ARCHIVE_ERROR), any(), any(), any(), any(), eq(MUNICIPALITY_ID), eq("No archive id returned"), any());
 	}
 
 	@Test
@@ -286,6 +291,7 @@ class ArchiveAttachmentServiceTest {
 		verify(archiveIntegrationMock).archive(any(ByggRArchiveRequest.class), eq(MUNICIPALITY_ID));
 		verify(fastighetService).getFastighet(any());
 		verify(messagingIntegrationMock).sendExtensionErrorEmail(archiveHistory, MUNICIPALITY_ID);
+		verify(archiveFailureRecorderMock).record(eq(FailureCategory.ARCHIVE_REJECTED_FORMAT), any(), any(), any(), any(), eq(MUNICIPALITY_ID), eq("Archive rejected file format"), any());
 	}
 
 	/**

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentServiceTest.java
@@ -15,6 +15,7 @@ import generated.se.sundsvall.arendeexport.HandelseHandling;
 import generated.se.sundsvall.bygglov.FastighetTyp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -148,7 +149,7 @@ class ArchiveAttachmentServiceTest {
 	@Test
 	void archiveWhenAnkomstDatumBefore2017() throws Exception {
 		// Arrange
-		final var arende = createArendeObject(List.of(AttachmentCategory.ANS)).withAnkomstDatum(LocalDate.of(2016, 12, 31));
+		final var arende = createArendeObject(List.of(AttachmentCategory.ANS)).withAnkomstDatum(LocalDate.of(2016, Month.DECEMBER, 31));
 		final var handling = arende.getHandelseLista().getHandelse().getFirst().getHandlingLista().getHandling().getFirst();
 		final var document = handling.getDokument();
 		final var archiveResponse = new ArchiveResponse();
@@ -181,7 +182,7 @@ class ArchiveAttachmentServiceTest {
 	@Test
 	void archiveWhenAnkomstDatumBefore1993() throws Exception {
 		// Arrange
-		final var arende = createArendeObject(List.of(AttachmentCategory.ANS)).withAnkomstDatum(LocalDate.of(1992, 12, 31));
+		final var arende = createArendeObject(List.of(AttachmentCategory.ANS)).withAnkomstDatum(LocalDate.of(1992, Month.DECEMBER, 31));
 		final var handling = arende.getHandelseLista().getHandelse().getFirst().getHandlingLista().getHandling().getFirst();
 		final var document = handling.getDokument();
 		final var archiveResponse = new ArchiveResponse();
@@ -309,7 +310,7 @@ class ArchiveAttachmentServiceTest {
 			final var dokumentFil = new DokumentFil();
 			dokumentFil.setFilAndelse("pdf");
 			dokument.setFil(dokumentFil);
-			dokument.setSkapadDatum(LocalDateTime.now().minusDays(30));
+			dokument.setSkapadDatum(LocalDateTime.of(2024, Month.JANUARY, 16, 0, 0).minusDays(30));
 			final var handling = new HandelseHandling();
 			handling.setTyp(category.name());
 			handling.setDokument(dokument);

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveFailureRecorderTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveFailureRecorderTest.java
@@ -1,0 +1,44 @@
+package se.sundsvall.byggrarchiver.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ArchiveFailureRecorderTest {
+
+	@Mock
+	private ArchiveFailureService archiveFailureServiceMock;
+
+	@InjectMocks
+	private ArchiveFailureRecorder archiveFailureRecorder;
+
+	@Test
+	void recordDelegatesToService() {
+		// Act
+		archiveFailureRecorder.record(FailureCategory.FILE_TOO_LARGE, "caseId", "documentId", "documentName", 5L, "2281", "message", "detail");
+
+		// Assert
+		verify(archiveFailureServiceMock).persist(FailureCategory.FILE_TOO_LARGE, "caseId", "documentId", "documentName", 5L, "2281", "message", "detail");
+	}
+
+	@Test
+	void recordNeverThrowsWhenServiceFails() {
+		// Arrange
+		doThrow(new RuntimeException("boom")).when(archiveFailureServiceMock)
+			.persist(any(), any(), any(), any(), any(), any(), any(), any());
+
+		// Act & Assert - recording a failure must never break the archiving pipeline
+		assertThatCode(() -> archiveFailureRecorder.record(FailureCategory.ARCHIVE_ERROR, "caseId", "documentId", "documentName", 5L, "2281", "message", "detail"))
+			.doesNotThrowAnyException();
+	}
+
+}

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveFailureRecorderTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveFailureRecorderTest.java
@@ -2,11 +2,16 @@ package se.sundsvall.byggrarchiver.service;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveFailure;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
+import se.sundsvall.byggrarchiver.integration.db.model.BatchHistory;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -21,23 +26,43 @@ class ArchiveFailureRecorderTest {
 	@InjectMocks
 	private ArchiveFailureRecorder archiveFailureRecorder;
 
-	@Test
-	void recordDelegatesToService() {
-		// Act
-		archiveFailureRecorder.record(FailureCategory.FILE_TOO_LARGE, "caseId", "documentId", "documentName", 5L, "2281", "message", "detail");
-
-		// Assert
-		verify(archiveFailureServiceMock).persist(FailureCategory.FILE_TOO_LARGE, "caseId", "documentId", "documentName", 5L, "2281", "message", "detail");
+	private static ArchiveHistory archiveHistory() {
+		return ArchiveHistory.builder()
+			.withCaseId("caseId")
+			.withDocumentId("documentId")
+			.withDocumentName("documentName")
+			.withMunicipalityId("2281")
+			.withBatchHistory(BatchHistory.builder().withId(5L).build())
+			.build();
 	}
 
 	@Test
-	void recordNeverThrowsWhenServiceFails() {
+	void recordFailureMapsArchiveHistoryAndDelegatesToService() {
+		// Act
+		archiveFailureRecorder.recordFailure(FailureCategory.FILE_TOO_LARGE, archiveHistory(), "message", "detail");
+
+		// Assert - identity is pulled off the ArchiveHistory
+		final var captor = ArgumentCaptor.forClass(ArchiveFailure.class);
+		verify(archiveFailureServiceMock).persist(captor.capture());
+
+		final var saved = captor.getValue();
+		assertThat(saved.getFailureCategory()).isEqualTo(FailureCategory.FILE_TOO_LARGE);
+		assertThat(saved.getCaseId()).isEqualTo("caseId");
+		assertThat(saved.getDocumentId()).isEqualTo("documentId");
+		assertThat(saved.getDocumentName()).isEqualTo("documentName");
+		assertThat(saved.getBatchHistoryId()).isEqualTo(5L);
+		assertThat(saved.getMunicipalityId()).isEqualTo("2281");
+		assertThat(saved.getMessage()).isEqualTo("message");
+		assertThat(saved.getDetail()).isEqualTo("detail");
+	}
+
+	@Test
+	void recordFailureNeverThrowsWhenServiceFails() {
 		// Arrange
-		doThrow(new RuntimeException("boom")).when(archiveFailureServiceMock)
-			.persist(any(), any(), any(), any(), any(), any(), any(), any());
+		doThrow(new RuntimeException("boom")).when(archiveFailureServiceMock).persist(any());
 
 		// Act & Assert - recording a failure must never break the archiving pipeline
-		assertThatCode(() -> archiveFailureRecorder.record(FailureCategory.ARCHIVE_ERROR, "caseId", "documentId", "documentName", 5L, "2281", "message", "detail"))
+		assertThatCode(() -> archiveFailureRecorder.recordFailure(FailureCategory.ARCHIVE_ERROR, archiveHistory(), "message", "detail"))
 			.doesNotThrowAnyException();
 	}
 

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveFailureServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveFailureServiceTest.java
@@ -1,0 +1,97 @@
+package se.sundsvall.byggrarchiver.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.byggrarchiver.api.model.enums.FailureCategory;
+import se.sundsvall.byggrarchiver.integration.db.ArchiveFailureRepository;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveFailure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ArchiveFailureServiceTest {
+
+	@Mock
+	private ArchiveFailureRepository archiveFailureRepositoryMock;
+
+	@InjectMocks
+	private ArchiveFailureService archiveFailureService;
+
+	@Test
+	void persistSavesMappedEntity() {
+		// Act
+		archiveFailureService.persist(FailureCategory.ARCHIVE_ERROR, "caseId", "documentId", "documentName", 5L, "2281", "message", "detail");
+
+		// Assert
+		final var captor = ArgumentCaptor.forClass(ArchiveFailure.class);
+		verify(archiveFailureRepositoryMock).save(captor.capture());
+		verifyNoMoreInteractions(archiveFailureRepositoryMock);
+
+		final var saved = captor.getValue();
+		assertThat(saved.getFailureCategory()).isEqualTo(FailureCategory.ARCHIVE_ERROR);
+		assertThat(saved.getCaseId()).isEqualTo("caseId");
+		assertThat(saved.getDocumentId()).isEqualTo("documentId");
+		assertThat(saved.getDocumentName()).isEqualTo("documentName");
+		assertThat(saved.getBatchHistoryId()).isEqualTo(5L);
+		assertThat(saved.getMunicipalityId()).isEqualTo("2281");
+		assertThat(saved.getMessage()).isEqualTo("message");
+		assertThat(saved.getDetail()).isEqualTo("detail");
+	}
+
+	@Test
+	void getFailuresMapsResults() {
+		// Arrange
+		final var entity = ArchiveFailure.builder()
+			.withId(1L)
+			.withBatchHistoryId(5L)
+			.withCaseId("caseId")
+			.withDocumentId("documentId")
+			.withMunicipalityId("2281")
+			.withDocumentName("documentName")
+			.withFailureCategory(FailureCategory.BYGGR_FETCH_ERROR)
+			.withMessage("message")
+			.withDetail("detail")
+			.withTimestamp(LocalDateTime.now())
+			.build();
+
+		when(archiveFailureRepositoryMock.findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(5L, "2281", FailureCategory.BYGGR_FETCH_ERROR))
+			.thenReturn(List.of(entity));
+
+		// Act
+		final var result = archiveFailureService.getFailures(5L, FailureCategory.BYGGR_FETCH_ERROR, "2281");
+
+		// Assert
+		assertThat(result).hasSize(1);
+		assertThat(result.getFirst().getId()).isEqualTo(1L);
+		assertThat(result.getFirst().getFailureCategory()).isEqualTo(FailureCategory.BYGGR_FETCH_ERROR);
+		assertThat(result.getFirst().getCaseId()).isEqualTo("caseId");
+		verify(archiveFailureRepositoryMock).findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(5L, "2281", FailureCategory.BYGGR_FETCH_ERROR);
+		verifyNoMoreInteractions(archiveFailureRepositoryMock);
+	}
+
+	@Test
+	void getFailuresPassesNullCategory() {
+		// Arrange
+		when(archiveFailureRepositoryMock.findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(any(), any(), any()))
+			.thenReturn(List.of());
+
+		// Act
+		final var result = archiveFailureService.getFailures(5L, null, "2281");
+
+		// Assert
+		assertThat(result).isEmpty();
+		verify(archiveFailureRepositoryMock).findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(5L, "2281", null);
+		verifyNoMoreInteractions(archiveFailureRepositoryMock);
+	}
+
+}

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveFailureServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveFailureServiceTest.java
@@ -1,6 +1,7 @@
 package se.sundsvall.byggrarchiver.service;
 
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,7 +56,7 @@ class ArchiveFailureServiceTest {
 			.withFailureCategory(FailureCategory.BYGGR_FETCH_ERROR)
 			.withMessage("message")
 			.withDetail("detail")
-			.withTimestamp(LocalDateTime.now())
+			.withTimestamp(LocalDateTime.of(2024, Month.JANUARY, 16, 12, 0))
 			.build();
 
 		when(archiveFailureRepositoryMock.findByBatchHistoryIdAndMunicipalityIdAndOptionalFailureCategory(5L, "2281", FailureCategory.BYGGR_FETCH_ERROR))

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveFailureServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveFailureServiceTest.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -28,24 +27,19 @@ class ArchiveFailureServiceTest {
 	private ArchiveFailureService archiveFailureService;
 
 	@Test
-	void persistSavesMappedEntity() {
+	void persistSavesEntity() {
+		// Arrange
+		final var archiveFailure = ArchiveFailure.builder()
+			.withFailureCategory(FailureCategory.ARCHIVE_ERROR)
+			.withCaseId("caseId")
+			.build();
+
 		// Act
-		archiveFailureService.persist(FailureCategory.ARCHIVE_ERROR, "caseId", "documentId", "documentName", 5L, "2281", "message", "detail");
+		archiveFailureService.persist(archiveFailure);
 
 		// Assert
-		final var captor = ArgumentCaptor.forClass(ArchiveFailure.class);
-		verify(archiveFailureRepositoryMock).save(captor.capture());
+		verify(archiveFailureRepositoryMock).save(archiveFailure);
 		verifyNoMoreInteractions(archiveFailureRepositoryMock);
-
-		final var saved = captor.getValue();
-		assertThat(saved.getFailureCategory()).isEqualTo(FailureCategory.ARCHIVE_ERROR);
-		assertThat(saved.getCaseId()).isEqualTo("caseId");
-		assertThat(saved.getDocumentId()).isEqualTo("documentId");
-		assertThat(saved.getDocumentName()).isEqualTo("documentName");
-		assertThat(saved.getBatchHistoryId()).isEqualTo(5L);
-		assertThat(saved.getMunicipalityId()).isEqualTo("2281");
-		assertThat(saved.getMessage()).isEqualTo("message");
-		assertThat(saved.getDetail()).isEqualTo("detail");
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryQueryServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryQueryServiceTest.java
@@ -1,0 +1,60 @@
+package se.sundsvall.byggrarchiver.service;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
+
+@ExtendWith(MockitoExtension.class)
+class ArchiveHistoryQueryServiceTest {
+
+	private static final String MUNICIPALITY_ID = "2281";
+
+	@Mock
+	private ArchiveHistoryRepository archiveHistoryRepositoryMock;
+
+	@InjectMocks
+	private ArchiveHistoryQueryService archiveHistoryQueryService;
+
+	@Test
+	void getArchiveHistoriesMapsResults() {
+		final var entity = ArchiveHistory.builder()
+			.withCaseId("caseId")
+			.withDocumentId("documentId")
+			.withArchiveStatus(COMPLETED)
+			.build();
+
+		when(archiveHistoryRepositoryMock.getArchiveHistoriesByArchiveStatusAndBatchHistoryIdAndMunicipalityId(COMPLETED, 1L, MUNICIPALITY_ID))
+			.thenReturn(List.of(entity));
+
+		final var result = archiveHistoryQueryService.getArchiveHistories(COMPLETED, 1L, MUNICIPALITY_ID);
+
+		assertThat(result).singleElement().satisfies(response -> {
+			assertThat(response.getCaseId()).isEqualTo("caseId");
+			assertThat(response.getDocumentId()).isEqualTo("documentId");
+			assertThat(response.getArchiveStatus()).isEqualTo(COMPLETED);
+		});
+		verify(archiveHistoryRepositoryMock).getArchiveHistoriesByArchiveStatusAndBatchHistoryIdAndMunicipalityId(COMPLETED, 1L, MUNICIPALITY_ID);
+		verifyNoMoreInteractions(archiveHistoryRepositoryMock);
+	}
+
+	@Test
+	void getArchiveHistoriesEmpty() {
+		when(archiveHistoryRepositoryMock.getArchiveHistoriesByArchiveStatusAndBatchHistoryIdAndMunicipalityId(any(), any(), any()))
+			.thenReturn(List.of());
+
+		assertThat(archiveHistoryQueryService.getArchiveHistories(null, null, MUNICIPALITY_ID)).isEmpty();
+	}
+
+}

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryServiceTest.java
@@ -590,7 +590,7 @@ class ArchiveHistoryServiceTest {
 		archiveHistoryService.handleArchiving(dokuments, arende, handling, archiveHistory, MUNICIPALITY_ID);
 
 		assertThat(archiveHistory.getArchiveStatus()).isEqualTo(NOT_COMPLETED_FILE_TO_LARGE);
-		verify(mockArchiveFailureRecorder).record(eq(FILE_TOO_LARGE), any(), any(), any(), eq(1L), eq(MUNICIPALITY_ID), eq("File too large"), any());
+		verify(mockArchiveFailureRecorder).recordFailure(eq(FILE_TOO_LARGE), eq(archiveHistory), eq("File too large"), any());
 	}
 
 	@Test
@@ -622,7 +622,8 @@ class ArchiveHistoryServiceTest {
 		final var result = archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, SCHEDULED), MUNICIPALITY_ID);
 
 		assertThat(result).isNotNull();
-		verify(mockArchiveFailureRecorder).record(eq(BYGGR_FETCH_ERROR), eq(arende.getDnr()), eq(docId), any(), any(), eq(MUNICIPALITY_ID), any(), any());
+		verify(mockArchiveFailureRecorder).recordFailure(eq(BYGGR_FETCH_ERROR), argThat(ah -> docId.equals(ah.getDocumentId()) && arende.getDnr().equals(ah.getCaseId()) && MUNICIPALITY_ID.equals(ah.getMunicipalityId())), eq("ByggR getDocument failed"),
+			any());
 		// Archiving of the attachment is never attempted because the fetch failed
 		verify(mockArchiveAttachmentService, never()).archiveAttachment(any(), any(), any(), any(), any());
 	}
@@ -655,7 +656,8 @@ class ArchiveHistoryServiceTest {
 		final var result = archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, SCHEDULED), MUNICIPALITY_ID);
 
 		assertThat(result).isNotNull();
-		verify(mockArchiveFailureRecorder).record(eq(BYGGR_FETCH_ERROR), eq(arende.getDnr()), eq(docId), any(), any(), eq(MUNICIPALITY_ID), any(), any());
+		verify(mockArchiveFailureRecorder).recordFailure(eq(BYGGR_FETCH_ERROR), argThat(ah -> docId.equals(ah.getDocumentId()) && arende.getDnr().equals(ah.getCaseId()) && MUNICIPALITY_ID.equals(ah.getMunicipalityId())), eq("ByggR getDocument failed"),
+			any());
 		verify(mockArchiveAttachmentService, never()).archiveAttachment(any(), any(), any(), any(), any());
 	}
 

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryServiceTest.java
@@ -14,8 +14,10 @@ import generated.se.sundsvall.arendeexport.Fastighet;
 import generated.se.sundsvall.arendeexport.Handelse;
 import generated.se.sundsvall.arendeexport.HandelseHandling;
 import generated.se.sundsvall.bygglov.FastighetTyp;
+import java.time.Clock;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -85,6 +87,8 @@ class ArchiveHistoryServiceTest {
 
 	private static final String ONGOING = "Pågående";
 	private static final String MUNICIPALITY_ID = "2281";
+	private static final LocalDate TODAY = LocalDate.of(2024, Month.JANUARY, 16);
+	private static final Clock CLOCK = Clock.fixed(TODAY.atStartOfDay(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
 
 	@Mock
 	private ArchiveAttachmentService mockArchiveAttachmentService;
@@ -132,6 +136,7 @@ class ArchiveHistoryServiceTest {
 			.when(mockMessagingIntegration).sendExtensionErrorEmail(any(ArchiveHistory.class), eq(MUNICIPALITY_ID));
 
 		ReflectionTestUtils.setField(archiveHistoryService, "maximumFileSize", 100000);
+		ReflectionTestUtils.setField(archiveHistoryService, "clock", CLOCK);
 
 		// FB
 		final var fastighetTyp = new FastighetTyp();
@@ -153,7 +158,7 @@ class ArchiveHistoryServiceTest {
 	@ParameterizedTest
 	@EnumSource(BatchTrigger.class)
 	void testBatch0Cases0Docs(final BatchTrigger batchTrigger) throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var result = archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, batchTrigger), MUNICIPALITY_ID);
 
@@ -168,7 +173,7 @@ class ArchiveHistoryServiceTest {
 	@ParameterizedTest
 	@EnumSource(BatchTrigger.class)
 	void testBatch1Cases0Docs(final BatchTrigger batchTrigger) throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var start = yesterday.atStartOfDay();
 		final var end = yesterday.atTime(23, 59, 59);
@@ -199,7 +204,7 @@ class ArchiveHistoryServiceTest {
 	@ParameterizedTest
 	@EnumSource(BatchTrigger.class)
 	void testBatch1Cases3DocsGetDocumentReturnsEmpty(final BatchTrigger batchTrigger) throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var start = yesterday.atStartOfDay();
 		final var end = yesterday.atTime(23, 59, 59);
@@ -236,7 +241,7 @@ class ArchiveHistoryServiceTest {
 	@ParameterizedTest
 	@EnumSource(BatchTrigger.class)
 	void testBatch1CaseWithWrongStatus3Docs(final BatchTrigger batchTrigger) throws ApplicationException {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var start = yesterday.atStartOfDay();
 		final var end = yesterday.atTime(23, 59, 59);
@@ -263,7 +268,7 @@ class ArchiveHistoryServiceTest {
 	@ParameterizedTest
 	@EnumSource(BatchTrigger.class)
 	void testBatch2Cases1WithWrongHandelseslag2Docs(final BatchTrigger batchTrigger) throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var start = yesterday.atStartOfDay();
 		final var end = yesterday.atTime(23, 59, 59);
@@ -298,14 +303,14 @@ class ArchiveHistoryServiceTest {
 	@ParameterizedTest
 	@EnumSource(BatchTrigger.class)
 	void testBatch1Case3Docs(final BatchTrigger batchTrigger) throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var arende = createArendeObject(BYGGR_STATUS_AVSLUTAT, BYGGR_HANDELSETYP_ARKIV, List.of(PLFASE, FASSIT2, TOMTPLBE));
 		final var arrayOfArende = new ArrayOfArende();
 		arrayOfArende.getArende().add(arende);
 		final var arendeBatch = new ArendeBatch();
-		arendeBatch.setBatchStart(LocalDateTime.now().minusDays(1).withHour(12).withMinute(0).withSecond(0));
-		arendeBatch.setBatchEnd(LocalDateTime.now().minusDays(1).withHour(23).withMinute(0).withSecond(0));
+		arendeBatch.setBatchStart(TODAY.minusDays(1).atTime(12, 0, 0));
+		arendeBatch.setBatchEnd(TODAY.minusDays(1).atTime(23, 0, 0));
 		arendeBatch.setArenden(arrayOfArende);
 
 		final var batchFilter = new BatchFilter();
@@ -328,7 +333,7 @@ class ArchiveHistoryServiceTest {
 	@ParameterizedTest
 	@EnumSource(BatchTrigger.class)
 	void testBatch3Cases1Ended1Doc(final BatchTrigger batchTrigger) throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var start = yesterday.atStartOfDay();
 		final var end = yesterday.atTime(23, 59, 59);
@@ -363,7 +368,7 @@ class ArchiveHistoryServiceTest {
 	@ParameterizedTest
 	@EnumSource(BatchTrigger.class)
 	void testBatch3Cases2Ended4Docs(final BatchTrigger batchTrigger) throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var start = yesterday.atStartOfDay();
 		final var end = yesterday.atTime(23, 59, 59);
@@ -405,7 +410,7 @@ class ArchiveHistoryServiceTest {
 	// and connected to this case is removed and that the old batch is updated with status completed.
 	@Test
 	void testUpdateStatusOfOldBatchHistories_1() throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var start = yesterday.atStartOfDay();
 		final var end = yesterday.atTime(23, 59, 59);
@@ -460,7 +465,7 @@ class ArchiveHistoryServiceTest {
 	// Verify an empty list also works in updateStatusOfOldBatchHistories
 	@Test
 	void testUpdateStatusOfOldBatchHistories_2() throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var start = yesterday.atStartOfDay();
 		final var end = yesterday.atTime(23, 59, 59);
@@ -505,7 +510,7 @@ class ArchiveHistoryServiceTest {
 	// Run batch for attachmentCategory "GEO" and verify email was sent
 	@Test
 	void runBatchGeotekniskUndersokningMessageSentTrue() throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var start = yesterday.atStartOfDay();
 		final var end = yesterday.atTime(23, 59, 59);
@@ -540,7 +545,7 @@ class ArchiveHistoryServiceTest {
 	// Run batch for attachmentCategory "GEO" and simulate the email was not sent.
 	@Test
 	void runBatchGeotekniskUndersokningMessageSentFalse() throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var start = yesterday.atStartOfDay();
 		final var end = yesterday.atTime(23, 59, 59);
@@ -595,7 +600,7 @@ class ArchiveHistoryServiceTest {
 
 	@Test
 	void getDocumentFaultIsRecordedAndDoesNotAbortBatch() throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var start = yesterday.atStartOfDay();
 		final var end = yesterday.atTime(23, 59, 59);
@@ -630,7 +635,7 @@ class ArchiveHistoryServiceTest {
 
 	@Test
 	void getDocumentNonProblemRuntimeFaultIsRecordedAndDoesNotAbortBatch() throws Exception {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		final var start = yesterday.atStartOfDay();
 		final var end = yesterday.atTime(23, 59, 59);
@@ -693,7 +698,7 @@ class ArchiveHistoryServiceTest {
 			dokumentFil.setFilAndelse("pdf");
 			dokument.setFil(dokumentFil);
 			dokumentFil.setFilBuffer(new byte[5]);
-			dokument.setSkapadDatum(LocalDateTime.now().minusDays(30));
+			dokument.setSkapadDatum(TODAY.minusDays(30).atStartOfDay());
 
 			dokumentList.add(dokument);
 

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryServiceTest.java
@@ -13,14 +13,12 @@ import generated.se.sundsvall.arendeexport.DokumentFil;
 import generated.se.sundsvall.arendeexport.Fastighet;
 import generated.se.sundsvall.arendeexport.Handelse;
 import generated.se.sundsvall.arendeexport.HandelseHandling;
-import generated.se.sundsvall.bygglov.FastighetTyp;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import org.hibernate.service.spi.ServiceException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,8 +37,6 @@ import se.sundsvall.byggrarchiver.integration.arendeexport.ArendeExportIntegrati
 import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
 import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
 import se.sundsvall.byggrarchiver.integration.db.model.BatchHistory;
-import se.sundsvall.byggrarchiver.integration.fb.FbIntegration;
-import se.sundsvall.byggrarchiver.integration.messaging.MessagingIntegration;
 import se.sundsvall.byggrarchiver.service.exceptions.ApplicationException;
 import se.sundsvall.byggrarchiver.testutils.BatchFilterMatcher;
 import se.sundsvall.dept44.problem.Problem;
@@ -48,10 +44,8 @@ import se.sundsvall.dept44.problem.Problem;
 import static java.lang.String.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
@@ -64,7 +58,6 @@ import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED_FILE_TO_LARGE;
 import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.FASSIT2;
-import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.GEO;
 import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.LUTE;
 import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.PLFASE;
 import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.RUE;
@@ -73,7 +66,6 @@ import static se.sundsvall.byggrarchiver.api.model.enums.BatchTrigger.SCHEDULED;
 import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.BYGGR_FETCH_ERROR;
 import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.FILE_TOO_LARGE;
 import static se.sundsvall.byggrarchiver.testutils.TestUtil.randomInt;
-import static se.sundsvall.byggrarchiver.testutils.TestUtil.randomLong;
 import static se.sundsvall.byggrarchiver.util.Constants.BYGGR_HANDELSETYP_ARKIV;
 import static se.sundsvall.byggrarchiver.util.Constants.BYGGR_STATUS_AVSLUTAT;
 
@@ -89,16 +81,13 @@ class ArchiveHistoryServiceTest {
 	private ArchiveAttachmentService mockArchiveAttachmentService;
 
 	@Mock
-	private MessagingIntegration mockMessagingIntegration;
-
-	@Mock
 	private ArchiveHistoryRepository mockArchiveHistoryRepository;
 
 	@Mock
 	private BatchCompletionService mockBatchCompletionService;
 
 	@Mock
-	private FbIntegration mockFastighetService;
+	private LantmaterietNotifier mockLantmaterietNotifier;
 
 	@Mock
 	private ArendeExportIntegration mockArendeExportIntegrationService;
@@ -119,26 +108,8 @@ class ArchiveHistoryServiceTest {
 			.when(mockArendeExportIntegrationService.getUpdatedArenden(any(BatchFilter.class)))
 			.thenReturn(new ArendeBatch().withArenden(new ArrayOfArende()));
 
-		// Messaging
-		lenient()
-			.doNothing()
-			.when(mockMessagingIntegration).sendEmailToLantmateriet(anyString(), any(ArchiveHistory.class), eq(MUNICIPALITY_ID));
-		lenient()
-			.doNothing()
-			.when(mockMessagingIntegration).sendExtensionErrorEmail(any(ArchiveHistory.class), eq(MUNICIPALITY_ID));
-
 		ReflectionTestUtils.setField(archiveHistoryService, "maximumFileSize", 100000);
 		ReflectionTestUtils.setField(archiveHistoryService, "clock", CLOCK);
-
-		// FB
-		final var fastighetTyp = new FastighetTyp();
-		fastighetTyp.setFastighetsbeteckning("Sundsvall Test beteckning 1");
-		fastighetTyp.setTrakt("Test trakt");
-		fastighetTyp.setObjektidentitet(UUID.randomUUID().toString());
-
-		lenient()
-			.when(mockFastighetService.getFastighet(any()))
-			.thenReturn(fastighetTyp);
 
 		// Long-term archive
 		lenient()
@@ -160,7 +131,7 @@ class ArchiveHistoryServiceTest {
 
 		// Closing out the batch is delegated to BatchCompletionService
 		verify(mockBatchCompletionService).completeBatch(result, MUNICIPALITY_ID);
-		verifyCalls(25, 0, 0, 0);
+		verifyCalls(25, 0, 0);
 	}
 
 	@ParameterizedTest
@@ -190,7 +161,7 @@ class ArchiveHistoryServiceTest {
 
 		archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, batchTrigger), MUNICIPALITY_ID);
 
-		verifyCalls(2, 0, 0, 0);
+		verifyCalls(2, 0, 0);
 	}
 
 	// GetDocument returns empty list for one of the documents
@@ -228,7 +199,7 @@ class ArchiveHistoryServiceTest {
 
 		archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, batchTrigger), MUNICIPALITY_ID);
 
-		verifyCalls(2, 3, 2, 0);
+		verifyCalls(2, 3, 2);
 	}
 
 	@ParameterizedTest
@@ -255,7 +226,7 @@ class ArchiveHistoryServiceTest {
 
 		archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, batchTrigger), MUNICIPALITY_ID);
 
-		verifyCalls(2, 0, 0, 0);
+		verifyCalls(2, 0, 0);
 	}
 
 	@ParameterizedTest
@@ -289,7 +260,7 @@ class ArchiveHistoryServiceTest {
 
 		archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, batchTrigger), MUNICIPALITY_ID);
 
-		verifyCalls(2, 2, 2, 0);
+		verifyCalls(2, 2, 2);
 	}
 
 	// Standard scenario - Run batch for yesterday - 1 case and 3 documents found
@@ -322,7 +293,7 @@ class ArchiveHistoryServiceTest {
 
 		// Stale NOT_COMPLETED histories for the closed case are removed before re-archiving
 		verify(mockArchiveHistoryRepository).deleteArchiveHistoriesByCaseIdAndArchiveStatus(arende.getDnr(), NOT_COMPLETED);
-		verifyCalls(3, 3, 3, 0);
+		verifyCalls(3, 3, 3);
 	}
 
 	@ParameterizedTest
@@ -357,7 +328,7 @@ class ArchiveHistoryServiceTest {
 
 		archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, batchTrigger), MUNICIPALITY_ID);
 
-		verifyCalls(2, 1, 1, 0);
+		verifyCalls(2, 1, 1);
 	}
 
 	@ParameterizedTest
@@ -398,80 +369,7 @@ class ArchiveHistoryServiceTest {
 
 		archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, batchTrigger), MUNICIPALITY_ID);
 
-		verifyCalls(2, 4, 4, 0);
-	}
-
-	// Run batch for attachmentCategory "GEO" and verify email was sent
-	@Test
-	void runBatchGeotekniskUndersokningMessageSentTrue() throws Exception {
-		final var yesterday = TODAY.minusDays(1);
-
-		final var start = yesterday.atStartOfDay();
-		final var end = yesterday.atTime(23, 59, 59);
-
-		final var batchFilter = new BatchFilter();
-		batchFilter.setLowerExclusiveBound(start);
-		batchFilter.setUpperInclusiveBound(end);
-
-		final var arrayOfArende = new ArrayOfArende();
-		final var arende = createArendeObject(BYGGR_STATUS_AVSLUTAT, BYGGR_HANDELSETYP_ARKIV, List.of(GEO, FASSIT2, GEO));
-		arrayOfArende.getArende().add(arende);
-		final var arendeBatch = new ArendeBatch();
-		arendeBatch.setBatchStart(start);
-		arendeBatch.setBatchEnd(end);
-		arendeBatch.setArenden(arrayOfArende);
-
-		doReturn(arendeBatch).when(mockArendeExportIntegrationService).getUpdatedArenden(argThat(new BatchFilterMatcher(batchFilter)));
-
-		final var archiveHistory = new ArchiveHistory();
-		archiveHistory.setArchiveStatus(COMPLETED);
-		archiveHistory.setArchiveId(valueOf(randomLong()));
-
-		when(mockArchiveAttachmentService.archiveAttachment(any(), any(), any(), any(), eq(MUNICIPALITY_ID)))
-			.thenReturn(archiveHistory);
-
-		// Test
-		archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, SCHEDULED), MUNICIPALITY_ID);
-
-		verifyCalls(2, 3, 3, 2);
-	}
-
-	// Run batch for attachmentCategory "GEO" and simulate the email was not sent.
-	@Test
-	void runBatchGeotekniskUndersokningMessageSentFalse() throws Exception {
-		final var yesterday = TODAY.minusDays(1);
-
-		final var start = yesterday.atStartOfDay();
-		final var end = yesterday.atTime(23, 59, 59);
-
-		final var batchFilter = new BatchFilter();
-		batchFilter.setLowerExclusiveBound(start);
-		batchFilter.setUpperInclusiveBound(end);
-
-		final var arrayOfArende = new ArrayOfArende();
-		final var arende = createArendeObject(BYGGR_STATUS_AVSLUTAT, BYGGR_HANDELSETYP_ARKIV, List.of(GEO, FASSIT2, TOMTPLBE));
-		arrayOfArende.getArende().add(arende);
-		final var arendeBatch = new ArendeBatch();
-		arendeBatch.setBatchStart(start);
-		arendeBatch.setBatchEnd(end);
-		arendeBatch.setArenden(arrayOfArende);
-
-		doReturn(arendeBatch).when(mockArendeExportIntegrationService).getUpdatedArenden(argThat(new BatchFilterMatcher(batchFilter)));
-
-		// mocks messaging
-		doNothing().when(mockMessagingIntegration).sendEmailToLantmateriet(anyString(), any(ArchiveHistory.class), eq(MUNICIPALITY_ID));
-
-		final var archiveHistory = new ArchiveHistory();
-		archiveHistory.setArchiveStatus(COMPLETED);
-		archiveHistory.setArchiveId(valueOf(randomLong()));
-
-		when(mockArchiveAttachmentService.archiveAttachment(any(), any(), any(), any(), eq(MUNICIPALITY_ID)))
-			.thenReturn(archiveHistory);
-
-		// Test
-		archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, SCHEDULED), MUNICIPALITY_ID);
-
-		verifyCalls(2, 3, 3, 1);
+		verifyCalls(2, 4, 4);
 	}
 
 	@Test
@@ -562,14 +460,13 @@ class ArchiveHistoryServiceTest {
 
 	private void verifyCalls(final int nrOfCallsToGetUpdatedArenden,
 		final int nrOfCallsToGetDocument,
-		final int nrOfCallsToArchiveAttachmentService,
-		final int nrOfCallsToSendEmailToLantmateriet) throws ServiceException, ApplicationException {
+		final int nrOfCallsToArchiveAttachmentService) throws ServiceException, ApplicationException {
 		verify(mockArendeExportIntegrationService, times(nrOfCallsToGetUpdatedArenden)).getUpdatedArenden(any());
 		verify(mockArendeExportIntegrationService, times(nrOfCallsToGetDocument)).getDocument(any());
 		verify(mockArchiveAttachmentService, times(nrOfCallsToArchiveAttachmentService)).archiveAttachment(any(), any(), any(), any(), eq(MUNICIPALITY_ID));
 
-		verify(mockMessagingIntegration, times(nrOfCallsToSendEmailToLantmateriet))
-			.sendEmailToLantmateriet(anyString(), any(ArchiveHistory.class), eq(MUNICIPALITY_ID));
+		// notifyIfGeoDocument is invoked once per archived attachment (it no-ops for non-GEO documents)
+		verify(mockLantmaterietNotifier, times(nrOfCallsToArchiveAttachmentService)).notifyIfGeoDocument(any(), any(), any(), eq(MUNICIPALITY_ID));
 	}
 
 	/**

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryServiceTest.java
@@ -627,6 +627,38 @@ class ArchiveHistoryServiceTest {
 		verify(mockArchiveAttachmentService, never()).archiveAttachment(any(), any(), any(), any(), any());
 	}
 
+	@Test
+	void getDocumentNonProblemRuntimeFaultIsRecordedAndDoesNotAbortBatch() throws Exception {
+		final var yesterday = LocalDate.now().minusDays(1);
+
+		final var start = yesterday.atStartOfDay();
+		final var end = yesterday.atTime(23, 59, 59);
+
+		final var batchFilter = new BatchFilter();
+		batchFilter.setLowerExclusiveBound(start);
+		batchFilter.setUpperInclusiveBound(end);
+
+		final var arende = createArendeObject(BYGGR_STATUS_AVSLUTAT, BYGGR_HANDELSETYP_ARKIV, List.of(PLFASE));
+		final var arrayOfArende = new ArrayOfArende();
+		arrayOfArende.getArende().add(arende);
+		final var arendeBatch = new ArendeBatch();
+		arendeBatch.setBatchStart(start);
+		arendeBatch.setBatchEnd(end);
+		arendeBatch.setArenden(arrayOfArende);
+
+		doReturn(arendeBatch).when(mockArendeExportIntegrationService).getUpdatedArenden(argThat(new BatchFilterMatcher(batchFilter)));
+
+		// A non-Problem runtime failure (e.g. CircuitBreaker CallNotPermittedException) must also be caught and recorded
+		final var docId = arende.getHandelseLista().getHandelse().getFirst().getHandlingLista().getHandling().getFirst().getDokument().getDokId();
+		doThrow(new IllegalStateException("circuit breaker open")).when(mockArendeExportIntegrationService).getDocument(docId);
+
+		final var result = archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, SCHEDULED), MUNICIPALITY_ID);
+
+		assertThat(result).isNotNull();
+		verify(mockArchiveFailureRecorder).record(eq(BYGGR_FETCH_ERROR), eq(arende.getDnr()), eq(docId), any(), any(), eq(MUNICIPALITY_ID), any(), any());
+		verify(mockArchiveAttachmentService, never()).archiveAttachment(any(), any(), any(), any(), any());
+	}
+
 	private void verifyCalls(final int nrOfCallsToGetUpdatedArenden,
 		final int nrOfCallsToGetDocument,
 		final int nrOfCallsToArchiveAttachmentService,

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryServiceTest.java
@@ -45,6 +45,7 @@ import se.sundsvall.byggrarchiver.integration.fb.FbIntegration;
 import se.sundsvall.byggrarchiver.integration.messaging.MessagingIntegration;
 import se.sundsvall.byggrarchiver.service.exceptions.ApplicationException;
 import se.sundsvall.byggrarchiver.testutils.BatchFilterMatcher;
+import se.sundsvall.dept44.problem.Problem;
 
 import static java.lang.String.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,10 +55,13 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED_FILE_TO_LARGE;
@@ -69,6 +73,8 @@ import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.PLFA
 import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.RUE;
 import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.TOMTPLBE;
 import static se.sundsvall.byggrarchiver.api.model.enums.BatchTrigger.SCHEDULED;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.BYGGR_FETCH_ERROR;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.FILE_TOO_LARGE;
 import static se.sundsvall.byggrarchiver.testutils.TestUtil.randomInt;
 import static se.sundsvall.byggrarchiver.testutils.TestUtil.randomLong;
 import static se.sundsvall.byggrarchiver.util.Constants.BYGGR_HANDELSETYP_ARKIV;
@@ -100,6 +106,9 @@ class ArchiveHistoryServiceTest {
 
 	@Mock
 	private LongTermArchiveProperties mockLongTermArchiveProperties;
+
+	@Mock
+	private ArchiveFailureRecorder mockArchiveFailureRecorder;
 
 	@InjectMocks
 	private ArchiveHistoryService archiveHistoryService;
@@ -576,11 +585,46 @@ class ArchiveHistoryServiceTest {
 		var arende = new Arende();
 		var handling = new HandelseHandling();
 		var archiveHistory = new ArchiveHistory();
+		archiveHistory.setBatchHistory(BatchHistory.builder().withId(1L).build());
 
 		archiveHistoryService.handleArchiving(dokuments, arende, handling, archiveHistory, MUNICIPALITY_ID);
 
 		assertThat(archiveHistory.getArchiveStatus()).isEqualTo(NOT_COMPLETED_FILE_TO_LARGE);
+		verify(mockArchiveFailureRecorder).record(eq(FILE_TOO_LARGE), any(), any(), any(), eq(1L), eq(MUNICIPALITY_ID), eq("File too large"), any());
+	}
 
+	@Test
+	void getDocumentFaultIsRecordedAndDoesNotAbortBatch() throws Exception {
+		final var yesterday = LocalDate.now().minusDays(1);
+
+		final var start = yesterday.atStartOfDay();
+		final var end = yesterday.atTime(23, 59, 59);
+
+		final var batchFilter = new BatchFilter();
+		batchFilter.setLowerExclusiveBound(start);
+		batchFilter.setUpperInclusiveBound(end);
+
+		final var arende = createArendeObject(BYGGR_STATUS_AVSLUTAT, BYGGR_HANDELSETYP_ARKIV, List.of(PLFASE));
+		final var arrayOfArende = new ArrayOfArende();
+		arrayOfArende.getArende().add(arende);
+		final var arendeBatch = new ArendeBatch();
+		arendeBatch.setBatchStart(start);
+		arendeBatch.setBatchEnd(end);
+		arendeBatch.setArenden(arrayOfArende);
+
+		doReturn(arendeBatch).when(mockArendeExportIntegrationService).getUpdatedArenden(argThat(new BatchFilterMatcher(batchFilter)));
+
+		// The single document fails to be fetched from ByggR
+		final var docId = arende.getHandelseLista().getHandelse().getFirst().getHandlingLista().getHandling().getFirst().getDokument().getDokId();
+		doThrow(Problem.valueOf(SERVICE_UNAVAILABLE, "ByggR down")).when(mockArendeExportIntegrationService).getDocument(docId);
+
+		// The fault must not propagate / abort the batch
+		final var result = archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, SCHEDULED), MUNICIPALITY_ID);
+
+		assertThat(result).isNotNull();
+		verify(mockArchiveFailureRecorder).record(eq(BYGGR_FETCH_ERROR), eq(arende.getDnr()), eq(docId), any(), any(), eq(MUNICIPALITY_ID), any(), any());
+		// Archiving of the attachment is never attempted because the fetch failed
+		verify(mockArchiveAttachmentService, never()).archiveAttachment(any(), any(), any(), any(), any());
 	}
 
 	private void verifyCalls(final int nrOfCallsToGetUpdatedArenden,

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ArchiveHistoryServiceTest.java
@@ -20,7 +20,6 @@ import java.time.Month;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.hibernate.service.spi.ServiceException;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,8 +27,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -40,7 +37,6 @@ import se.sundsvall.byggrarchiver.api.model.enums.BatchTrigger;
 import se.sundsvall.byggrarchiver.configuration.LongTermArchiveProperties;
 import se.sundsvall.byggrarchiver.integration.arendeexport.ArendeExportIntegration;
 import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
-import se.sundsvall.byggrarchiver.integration.db.BatchHistoryRepository;
 import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
 import se.sundsvall.byggrarchiver.integration.db.model.BatchHistory;
 import se.sundsvall.byggrarchiver.integration.fb.FbIntegration;
@@ -67,7 +63,6 @@ import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED;
 import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED_FILE_TO_LARGE;
-import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.ANS;
 import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.FASSIT2;
 import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.GEO;
 import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.LUTE;
@@ -100,7 +95,7 @@ class ArchiveHistoryServiceTest {
 	private ArchiveHistoryRepository mockArchiveHistoryRepository;
 
 	@Mock
-	private BatchHistoryRepository mockBatchHistoryRepository;
+	private BatchCompletionService mockBatchCompletionService;
 
 	@Mock
 	private FbIntegration mockFastighetService;
@@ -116,9 +111,6 @@ class ArchiveHistoryServiceTest {
 
 	@InjectMocks
 	private ArchiveHistoryService archiveHistoryService;
-
-	@Captor
-	private ArgumentCaptor<BatchHistory> batchHistoryCaptor;
 
 	@BeforeEach
 	void beforeEach() throws Exception {
@@ -165,8 +157,9 @@ class ArchiveHistoryServiceTest {
 		assertThat(result.getStart()).isEqualTo(yesterday);
 		assertThat(result.getEnd()).isEqualTo(yesterday);
 		assertThat(result.getBatchTrigger()).isEqualTo(batchTrigger);
-		assertThat(result.getArchiveStatus()).isEqualTo(COMPLETED);
 
+		// Closing out the batch is delegated to BatchCompletionService
+		verify(mockBatchCompletionService).completeBatch(result, MUNICIPALITY_ID);
 		verifyCalls(25, 0, 0, 0);
 	}
 
@@ -327,6 +320,8 @@ class ArchiveHistoryServiceTest {
 
 		archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, batchTrigger), MUNICIPALITY_ID);
 
+		// Stale NOT_COMPLETED histories for the closed case are removed before re-archiving
+		verify(mockArchiveHistoryRepository).deleteArchiveHistoriesByCaseIdAndArchiveStatus(arende.getDnr(), NOT_COMPLETED);
 		verifyCalls(3, 3, 3, 0);
 	}
 
@@ -404,107 +399,6 @@ class ArchiveHistoryServiceTest {
 		archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, batchTrigger), MUNICIPALITY_ID);
 
 		verifyCalls(2, 4, 4, 0);
-	}
-
-	// Test run a batch with a case that has already been archived. Verify that every archive history that is not completed
-	// and connected to this case is removed and that the old batch is updated with status completed.
-	@Test
-	void testUpdateStatusOfOldBatchHistories_1() throws Exception {
-		final var yesterday = TODAY.minusDays(1);
-
-		final var start = yesterday.atStartOfDay();
-		final var end = yesterday.atTime(23, 59, 59);
-
-		final var arrayOfArende = new ArrayOfArende();
-		final var arende = createArendeObject(BYGGR_STATUS_AVSLUTAT, BYGGR_HANDELSETYP_ARKIV, List.of(ANS, FASSIT2, TOMTPLBE));
-		arrayOfArende.getArende().add(arende);
-		final var arendeBatch = new ArendeBatch();
-		arendeBatch.setBatchStart(start);
-		arendeBatch.setBatchEnd(end);
-		arendeBatch.setArenden(arrayOfArende);
-
-		doReturn(arendeBatch).when(mockArendeExportIntegrationService).getUpdatedArenden(any());
-		doReturn(Optional.empty()).when(mockArchiveHistoryRepository).getArchiveHistoryByDocumentIdAndCaseIdAndMunicipalityId(any(), any(), eq(MUNICIPALITY_ID));
-
-		doReturn(List.of(ArchiveHistory.builder()
-			.withArchiveStatus(COMPLETED)
-			.build()))
-			.when(mockArchiveHistoryRepository).getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(any(), eq(MUNICIPALITY_ID));
-
-		final var batch1 = BatchHistory.builder()
-			.withId(randomLong())
-			.withArchiveStatus(NOT_COMPLETED)
-			.build();
-		doReturn(List.of(batch1)).when(mockBatchHistoryRepository).findBatchHistoriesByArchiveStatusAndMunicipalityId(NOT_COMPLETED, MUNICIPALITY_ID);
-
-		final var archiveHistory1 = ArchiveHistory.builder()
-			.withArchiveStatus(COMPLETED)
-			.withBatchHistory(batch1)
-			.build();
-
-		final var archiveHistory2 = ArchiveHistory.builder()
-			.withArchiveStatus(COMPLETED)
-			.withBatchHistory(batch1)
-			.build();
-
-		doReturn(List.of(archiveHistory1, archiveHistory2)).when(mockArchiveHistoryRepository).getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(batch1.getId(), MUNICIPALITY_ID);
-
-		when(mockArchiveAttachmentService.archiveAttachment(any(), any(), any(), any(), eq(MUNICIPALITY_ID)))
-			.thenReturn(archiveHistory1);
-
-		archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, SCHEDULED), MUNICIPALITY_ID);
-
-		// verify deleteArchiveHistoriesByCaseIdAndArchiveStatus
-		verify(mockArchiveHistoryRepository, times(2)).deleteArchiveHistoriesByCaseIdAndArchiveStatus(arende.getDnr(), NOT_COMPLETED);
-		verify(mockBatchHistoryRepository, times(2)).save(batchHistoryCaptor.capture());
-
-		final var batchHistory1 = batchHistoryCaptor.getAllValues().stream().filter(bh -> batch1.getId().equals(bh.getId())).findFirst().orElseThrow();
-		assertThat(batchHistory1.getArchiveStatus()).isEqualTo(COMPLETED);
-	}
-
-	// Verify an empty list also works in updateStatusOfOldBatchHistories
-	@Test
-	void testUpdateStatusOfOldBatchHistories_2() throws Exception {
-		final var yesterday = TODAY.minusDays(1);
-
-		final var start = yesterday.atStartOfDay();
-		final var end = yesterday.atTime(23, 59, 59);
-
-		final var arrayOfArende = new ArrayOfArende();
-		final var arende = createArendeObject(BYGGR_STATUS_AVSLUTAT, BYGGR_HANDELSETYP_ARKIV, List.of(ANS, FASSIT2, TOMTPLBE));
-		arrayOfArende.getArende().add(arende);
-		final var arendeBatch = new ArendeBatch();
-		arendeBatch.setBatchStart(start);
-		arendeBatch.setBatchEnd(end);
-		arendeBatch.setArenden(arrayOfArende);
-
-		doReturn(arendeBatch).when(mockArendeExportIntegrationService).getUpdatedArenden(any());
-		doReturn(Optional.empty()).when(mockArchiveHistoryRepository).getArchiveHistoryByDocumentIdAndCaseIdAndMunicipalityId(any(), any(), eq(MUNICIPALITY_ID));
-
-		doReturn(new ArrayList<>()).when(mockArchiveHistoryRepository).getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(any(), eq(MUNICIPALITY_ID));
-
-		final var batch1 = BatchHistory.builder()
-			.withArchiveStatus(NOT_COMPLETED)
-			.withId(randomLong())
-			.build();
-		doReturn(List.of(batch1)).when(mockBatchHistoryRepository).findBatchHistoriesByArchiveStatusAndMunicipalityId(NOT_COMPLETED, MUNICIPALITY_ID);
-		doReturn(new ArrayList<>()).when(mockArchiveHistoryRepository).getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(batch1.getId(), MUNICIPALITY_ID);
-
-		final var archiveHistory = new ArchiveHistory();
-		archiveHistory.setArchiveStatus(COMPLETED);
-		archiveHistory.setBatchHistory(batch1);
-
-		when(mockArchiveAttachmentService.archiveAttachment(any(), any(), any(), any(), eq(MUNICIPALITY_ID)))
-			.thenReturn(archiveHistory);
-
-		archiveHistoryService.archive(yesterday, yesterday, createBatchHistory(yesterday, yesterday, SCHEDULED), MUNICIPALITY_ID);
-
-		// verify deleteArchiveHistoriesByCaseIdAndArchiveStatus
-		verify(mockArchiveHistoryRepository, times(2)).deleteArchiveHistoriesByCaseIdAndArchiveStatus(arende.getDnr(), NOT_COMPLETED);
-		verify(mockBatchHistoryRepository, times(2)).save(batchHistoryCaptor.capture());
-
-		final var batchHistory1 = batchHistoryCaptor.getAllValues().stream().filter(bh -> batch1.getId().equals(bh.getId())).findFirst().orElseThrow();
-		assertThat(batchHistory1.getArchiveStatus()).isEqualTo(COMPLETED);
 	}
 
 	// Run batch for attachmentCategory "GEO" and verify email was sent

--- a/src/test/java/se/sundsvall/byggrarchiver/service/BatchCompletionServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/BatchCompletionServiceTest.java
@@ -1,0 +1,108 @@
+package se.sundsvall.byggrarchiver.service;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus;
+import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
+import se.sundsvall.byggrarchiver.integration.db.BatchHistoryRepository;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
+import se.sundsvall.byggrarchiver.integration.db.model.BatchHistory;
+import se.sundsvall.byggrarchiver.integration.messaging.MessagingIntegration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
+import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED;
+
+@ExtendWith(MockitoExtension.class)
+class BatchCompletionServiceTest {
+
+	private static final String MUNICIPALITY_ID = "2281";
+
+	@Mock
+	private BatchHistoryRepository batchHistoryRepositoryMock;
+
+	@Mock
+	private ArchiveHistoryRepository archiveHistoryRepositoryMock;
+
+	@Mock
+	private MessagingIntegration messagingIntegrationMock;
+
+	@InjectMocks
+	private BatchCompletionService batchCompletionService;
+
+	private static ArchiveHistory history(final ArchiveStatus status) {
+		return ArchiveHistory.builder().withArchiveStatus(status).build();
+	}
+
+	private static BatchHistory batch(final Long id) {
+		return BatchHistory.builder().withId(id).withArchiveStatus(NOT_COMPLETED).build();
+	}
+
+	@Test
+	void marksBatchCompletedWhenAllArchiveHistoriesCompleted() {
+		final var currentBatch = batch(1L);
+		when(archiveHistoryRepositoryMock.getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(1L, MUNICIPALITY_ID))
+			.thenReturn(List.of(history(COMPLETED), history(COMPLETED)));
+		when(batchHistoryRepositoryMock.findBatchHistoriesByArchiveStatusAndMunicipalityId(NOT_COMPLETED, MUNICIPALITY_ID))
+			.thenReturn(List.of());
+
+		batchCompletionService.completeBatch(currentBatch, MUNICIPALITY_ID);
+
+		assertThat(currentBatch.getArchiveStatus()).isEqualTo(COMPLETED);
+		verify(batchHistoryRepositoryMock).save(currentBatch);
+		verifyNoInteractions(messagingIntegrationMock);
+	}
+
+	@Test
+	void sendsStatusMailWhenBatchNotCompletedAndDoesNotPromotePendingOldBatch() {
+		final var currentBatch = batch(1L);
+		final var oldBatch = batch(2L);
+		final var histories = List.of(history(COMPLETED), history(NOT_COMPLETED));
+
+		when(archiveHistoryRepositoryMock.getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(1L, MUNICIPALITY_ID))
+			.thenReturn(histories);
+		when(batchHistoryRepositoryMock.findBatchHistoriesByArchiveStatusAndMunicipalityId(NOT_COMPLETED, MUNICIPALITY_ID))
+			.thenReturn(List.of(oldBatch));
+		when(archiveHistoryRepositoryMock.getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(2L, MUNICIPALITY_ID))
+			.thenReturn(List.of(history(NOT_COMPLETED)));
+
+		batchCompletionService.completeBatch(currentBatch, MUNICIPALITY_ID);
+
+		assertThat(currentBatch.getArchiveStatus()).isEqualTo(NOT_COMPLETED);
+		assertThat(oldBatch.getArchiveStatus()).isEqualTo(NOT_COMPLETED);
+		verify(messagingIntegrationMock).sendStatusMail(histories, 1L, MUNICIPALITY_ID);
+		verify(batchHistoryRepositoryMock, never()).save(any());
+	}
+
+	@Test
+	void promotesOldNotCompletedBatchWhoseDocumentsAreNowAllCompleted() {
+		final var currentBatch = batch(1L);
+		final var oldBatch = batch(2L);
+
+		when(archiveHistoryRepositoryMock.getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(1L, MUNICIPALITY_ID))
+			.thenReturn(List.of(history(COMPLETED)));
+		when(batchHistoryRepositoryMock.findBatchHistoriesByArchiveStatusAndMunicipalityId(NOT_COMPLETED, MUNICIPALITY_ID))
+			.thenReturn(List.of(oldBatch));
+		when(archiveHistoryRepositoryMock.getArchiveHistoriesByBatchHistoryIdAndMunicipalityId(2L, MUNICIPALITY_ID))
+			.thenReturn(List.of(history(COMPLETED)));
+
+		batchCompletionService.completeBatch(currentBatch, MUNICIPALITY_ID);
+
+		assertThat(currentBatch.getArchiveStatus()).isEqualTo(COMPLETED);
+		assertThat(oldBatch.getArchiveStatus()).isEqualTo(COMPLETED);
+		verify(batchHistoryRepositoryMock).save(currentBatch);
+		verify(batchHistoryRepositoryMock).save(oldBatch);
+		verify(messagingIntegrationMock, never()).sendStatusMail(any(), eq(1L), eq(MUNICIPALITY_ID));
+	}
+
+}

--- a/src/test/java/se/sundsvall/byggrarchiver/service/ByggrArchiverServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/ByggrArchiverServiceTest.java
@@ -17,7 +17,7 @@ import generated.se.sundsvall.arendeexport.Handelse;
 import generated.se.sundsvall.arendeexport.HandelseHandling;
 import generated.sokigo.fb.FastighetDto;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -74,6 +74,7 @@ import static se.sundsvall.byggrarchiver.testutils.TestUtil.randomLong;
 class ByggrArchiverServiceTest {
 
 	private static final String MUNICIPALITY_ID = "2281";
+	private static final LocalDate TODAY = LocalDate.of(2024, Month.JANUARY, 16);
 
 	@Mock
 	ArchiveHistoryService mockArchiveHistoryService;
@@ -143,7 +144,7 @@ class ByggrArchiverServiceTest {
 	// Try to run scheduled batch for the same date and verify it doesn't run
 	@Test
 	void testRunScheduledBatchForSameDate() {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 		final var batchHistory = BatchHistory.builder().withStart(yesterday).withEnd(yesterday).withArchiveStatus(COMPLETED).build();
 
 		when(mockArchiveHistoryService.archive(any(), any(), batchHistoryCaptor.capture(), eq(MUNICIPALITY_ID))).thenReturn(batchHistory);
@@ -163,7 +164,7 @@ class ByggrArchiverServiceTest {
 
 	@Test
 	void testRunManualBatchForSameDate() {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 
 		when(mockArchiveHistoryService.archive(any(), any(), batchHistoryCaptor.capture(), eq(MUNICIPALITY_ID))).thenReturn(BatchHistory.builder().withStart(yesterday).withEnd(yesterday).withArchiveStatus(COMPLETED).build());
 
@@ -183,8 +184,8 @@ class ByggrArchiverServiceTest {
 	@ParameterizedTest
 	@EnumSource(BatchTrigger.class)
 	void testTimeGapScheduled(final BatchTrigger batchTrigger) {
-		final var aLongTimeAgo = LocalDate.now().minusDays(20);
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var aLongTimeAgo = TODAY.minusDays(20);
+		final var yesterday = TODAY.minusDays(1);
 		final var batchHistory = BatchHistory.builder().withStart(aLongTimeAgo).withEnd(aLongTimeAgo).withArchiveStatus(COMPLETED).build();
 
 		when(mockArchiveHistoryService.archive(any(), any(), batchHistoryCaptor.capture(), eq(MUNICIPALITY_ID))).thenReturn(batchHistory);
@@ -208,14 +209,14 @@ class ByggrArchiverServiceTest {
 	@ParameterizedTest
 	@EnumSource(BatchTrigger.class)
 	void testTimeGapManual(final BatchTrigger batchTrigger) {
-		final var aLongTimeAgo = LocalDate.now().minusDays(20);
+		final var aLongTimeAgo = TODAY.minusDays(20);
 
 		when(mockArchiveHistoryService.archive(any(), any(), batchHistoryCaptor.capture(), eq(MUNICIPALITY_ID))).thenReturn(BatchHistory.builder().withStart(aLongTimeAgo).withEnd(aLongTimeAgo).withArchiveStatus(COMPLETED).build());
 
 		// Run the first batch
 		byggrArchiverService.runBatch(aLongTimeAgo, aLongTimeAgo, batchTrigger, MUNICIPALITY_ID);
 
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 		byggrArchiverService.runBatch(yesterday, yesterday, MANUAL, MUNICIPALITY_ID);
 
 		// First batch should have the same start and end date
@@ -228,7 +229,7 @@ class ByggrArchiverServiceTest {
 
 	@Test
 	void testRunBatchScheduledWhenLatestBatchIsAfterCurrent() {
-		final var today = LocalDate.now();
+		final var today = TODAY;
 
 		when(mockBatchHistoryRepository.findAll()).thenReturn(List.of(BatchHistory.builder().withStart(today.plusDays(1)).withEnd(today.plusDays(1)).withArchiveStatus(COMPLETED).build()));
 
@@ -242,7 +243,7 @@ class ByggrArchiverServiceTest {
 	// Rerun an earlier not_completed batch - GET batchhistory and verify it was completed
 	@Test
 	void testReRunNotCompletedBatch() {
-		final var yesterday = LocalDate.now().minusDays(1);
+		final var yesterday = TODAY.minusDays(1);
 		final var arrayOfArende = new ArrayOfArende();
 		final var arende = createArendeObject(List.of(GEO, FASSIT2, TOMTPLBE));
 		arrayOfArende.getArende().add(arende);
@@ -278,8 +279,8 @@ class ByggrArchiverServiceTest {
 	@Test
 	void rerunBatch() {
 		final var randomId = randomLong();
-		final var start = LocalDate.now().minusDays(7);
-		final var end = LocalDate.now().minusDays(7);
+		final var start = TODAY.minusDays(7);
+		final var end = TODAY.minusDays(7);
 
 		when(mockBatchHistoryRepository.findById(randomId))
 			.thenReturn(Optional.of(BatchHistory.builder().withStart(start).withEnd(end).withId(randomId).withArchiveStatus(NOT_COMPLETED).build()));
@@ -306,8 +307,8 @@ class ByggrArchiverServiceTest {
 	@Test
 	void rerunBatchCompleted() {
 		final var randomId = randomLong();
-		final var start = LocalDate.now().minusDays(7);
-		final var end = LocalDate.now().minusDays(7);
+		final var start = TODAY.minusDays(7);
+		final var end = TODAY.minusDays(7);
 
 		when(mockBatchHistoryRepository.findById(randomId))
 			.thenReturn(Optional.of(BatchHistory.builder().withStart(start).withEnd(end).withId(randomId).withArchiveStatus(COMPLETED).build()));
@@ -334,7 +335,7 @@ class ByggrArchiverServiceTest {
 			final var dokumentFil = new DokumentFil();
 			dokumentFil.setFilAndelse("pdf");
 			dokument.setFil(dokumentFil);
-			dokument.setSkapadDatum(LocalDateTime.now().minusDays(30));
+			dokument.setSkapadDatum(TODAY.minusDays(30).atStartOfDay());
 
 			dokumentList.add(dokument);
 

--- a/src/test/java/se/sundsvall/byggrarchiver/service/LantmaterietNotifierTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/LantmaterietNotifierTest.java
@@ -1,0 +1,102 @@
+package se.sundsvall.byggrarchiver.service;
+
+import generated.se.sundsvall.arendeexport.Arende2;
+import generated.se.sundsvall.arendeexport.ArendeFastighet;
+import generated.se.sundsvall.arendeexport.ArrayOfAbstractArendeObjekt2;
+import generated.se.sundsvall.arendeexport.Fastighet;
+import generated.se.sundsvall.arendeexport.Handling;
+import generated.se.sundsvall.bygglov.FastighetTyp;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
+import se.sundsvall.byggrarchiver.integration.fb.FbIntegration;
+import se.sundsvall.byggrarchiver.integration.messaging.MessagingIntegration;
+import se.sundsvall.byggrarchiver.service.exceptions.ApplicationException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.COMPLETED;
+import static se.sundsvall.byggrarchiver.api.model.enums.ArchiveStatus.NOT_COMPLETED;
+import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.FASSIT2;
+import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.GEO;
+
+@ExtendWith(MockitoExtension.class)
+class LantmaterietNotifierTest {
+
+	private static final String MUNICIPALITY_ID = "2281";
+
+	@Mock
+	private FbIntegration fbIntegrationMock;
+
+	@Mock
+	private MessagingIntegration messagingIntegrationMock;
+
+	@InjectMocks
+	private LantmaterietNotifier lantmaterietNotifier;
+
+	private static Arende2 arendeWithHuvudObjekt() {
+		final var fastighet = new Fastighet();
+		fastighet.setFnr(123456);
+		final var arendeFastighet = new ArendeFastighet();
+		arendeFastighet.setFastighet(fastighet);
+		arendeFastighet.setArHuvudObjekt(true);
+		final var objektLista = new ArrayOfAbstractArendeObjekt2();
+		objektLista.getAbstractArendeObjekt().add(arendeFastighet);
+		final var arende = new Arende2();
+		arende.setObjektLista(objektLista);
+		return arende;
+	}
+
+	private static Handling handling(final String typ) {
+		final var handling = new Handling();
+		handling.setTyp(typ);
+		return handling;
+	}
+
+	private static ArchiveHistory archiveHistory(final ArchiveStatus status, final String archiveId) {
+		final var archiveHistory = new ArchiveHistory();
+		archiveHistory.setArchiveStatus(status);
+		archiveHistory.setArchiveId(archiveId);
+		return archiveHistory;
+	}
+
+	@Test
+	void sendsEmailForCompletedGeoDocument() throws ApplicationException {
+		final var archiveHistory = archiveHistory(COMPLETED, "archive-1");
+		final var fastighet = new FastighetTyp();
+		fastighet.setFastighetsbeteckning("Sundsvall Test 1");
+		when(fbIntegrationMock.getFastighet(any())).thenReturn(fastighet);
+
+		lantmaterietNotifier.notifyIfGeoDocument(arendeWithHuvudObjekt(), handling(GEO.getCode()), archiveHistory, MUNICIPALITY_ID);
+
+		verify(messagingIntegrationMock).sendEmailToLantmateriet("Sundsvall Test 1", archiveHistory, MUNICIPALITY_ID);
+	}
+
+	@Test
+	void doesNothingForNonGeoDocument() throws ApplicationException {
+		lantmaterietNotifier.notifyIfGeoDocument(arendeWithHuvudObjekt(), handling(FASSIT2.getCode()), archiveHistory(COMPLETED, "archive-1"), MUNICIPALITY_ID);
+
+		verifyNoInteractions(fbIntegrationMock, messagingIntegrationMock);
+	}
+
+	@Test
+	void doesNothingWhenNotCompleted() throws ApplicationException {
+		lantmaterietNotifier.notifyIfGeoDocument(arendeWithHuvudObjekt(), handling(GEO.getCode()), archiveHistory(NOT_COMPLETED, "archive-1"), MUNICIPALITY_ID);
+
+		verifyNoInteractions(fbIntegrationMock, messagingIntegrationMock);
+	}
+
+	@Test
+	void doesNothingWhenArchiveIdMissing() throws ApplicationException {
+		lantmaterietNotifier.notifyIfGeoDocument(arendeWithHuvudObjekt(), handling(GEO.getCode()), archiveHistory(COMPLETED, null), MUNICIPALITY_ID);
+
+		verifyNoInteractions(fbIntegrationMock, messagingIntegrationMock);
+	}
+
+}

--- a/src/test/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapperTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapperTest.java
@@ -311,9 +311,9 @@ class ArchiverMapperTest {
 	}
 
 	@Test
-	void testToAttachmentCategory() {
-		assertThat(ArchiverMapper.toAttachmentCategory(FAS.toString())).isEqualTo(FAS);
-		assertThat(ArchiverMapper.toAttachmentCategory("NonExistingCategory")).isEqualTo(BIL);
+	void testGetAttachmentCategory() {
+		assertThat(ArchiverMapper.getAttachmentCategory(FAS.toString())).isEqualTo(FAS);
+		assertThat(ArchiverMapper.getAttachmentCategory("NonExistingCategory")).isEqualTo(BIL);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapperTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapperTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import se.sundsvall.byggrarchiver.integration.db.model.ArchiveFailure;
@@ -41,13 +42,13 @@ class ArchiverMapperTest {
 	@Test
 	void testToArchiveHistory() {
 		final var handling = new Handling()
-			.withHandlingDatum(LocalDate.of(2023, 1, 1))
+			.withHandlingDatum(LocalDate.of(2023, Month.JANUARY, 1))
 			.withAnteckning("anteckning")
 			.withDokument(new Dokument().withDokId("dokId").withNamn("namn").withFil(new DokumentFil().withFilBuffer(new byte[] {
 				1, 2, 3
 			}).withFilAndelse("pdf")));
 
-		final var batchHistory = createBatchHistory(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 1), SCHEDULED, COMPLETED);
+		final var batchHistory = createBatchHistory(LocalDate.of(2023, Month.JANUARY, 1), LocalDate.of(2023, Month.JANUARY, 1), SCHEDULED, COMPLETED);
 
 		final var archiveHistory = ArchiverMapper.toArchiveHistory(handling, batchHistory, "caseId", FASSIT2, COMPLETED, "2281");
 
@@ -124,7 +125,7 @@ class ArchiverMapperTest {
 			.withFailureCategory(ARCHIVE_ERROR)
 			.withMessage("message")
 			.withDetail("detail")
-			.withTimestamp(LocalDateTime.of(2023, 1, 1, 12, 0))
+			.withTimestamp(LocalDateTime.of(2023, Month.JANUARY, 1, 12, 0))
 			.build();
 
 		final var response = ArchiverMapper.mapToArchiveFailureResponse(entity);
@@ -139,7 +140,7 @@ class ArchiverMapperTest {
 		assertThat(response.getFailureCategory()).isEqualTo(ARCHIVE_ERROR);
 		assertThat(response.getMessage()).isEqualTo("message");
 		assertThat(response.getDetail()).isEqualTo("detail");
-		assertThat(response.getTimestamp()).isEqualTo(LocalDateTime.of(2023, 1, 1, 12, 0));
+		assertThat(response.getTimestamp()).isEqualTo(LocalDateTime.of(2023, Month.JANUARY, 1, 12, 0));
 	}
 
 	@Test
@@ -260,7 +261,7 @@ class ArchiverMapperTest {
 
 	@Test
 	void testToArkivbildarStrukturAfter2016() {
-		final var arkivbildarStruktur = ArchiverMapper.toArkivbildarStruktur(LocalDate.now());
+		final var arkivbildarStruktur = ArchiverMapper.toArkivbildarStruktur(LocalDate.of(2024, Month.JANUARY, 16));
 
 		assertThat(arkivbildarStruktur.getArkivbildare().getArkivbildare().getNamn()).isEqualTo("Stadsbyggnadsnämnden");
 		assertThat(arkivbildarStruktur.getArkivbildare().getArkivbildare().getVerksamhetstidFran()).isEqualTo("2017");
@@ -273,7 +274,7 @@ class ArchiverMapperTest {
 
 	@Test
 	void testToArkivbildarStrukturBefore1993() {
-		final var arkivbildarStruktur = ArchiverMapper.toArkivbildarStruktur(LocalDate.of(1992, 12, 31));
+		final var arkivbildarStruktur = ArchiverMapper.toArkivbildarStruktur(LocalDate.of(1992, Month.DECEMBER, 31));
 
 		assertThat(arkivbildarStruktur.getArkivbildare().getArkivbildare().getNamn()).isEqualTo("Byggnadsnämnden");
 		assertThat(arkivbildarStruktur.getArkivbildare().getArkivbildare().getVerksamhetstidFran()).isEqualTo("1974");
@@ -286,7 +287,7 @@ class ArchiverMapperTest {
 
 	@Test
 	void testToArkivbildarStrukturBetween1993And2016() {
-		final var arkivbildarStruktur = ArchiverMapper.toArkivbildarStruktur(LocalDate.of(1993, 1, 1));
+		final var arkivbildarStruktur = ArchiverMapper.toArkivbildarStruktur(LocalDate.of(1993, Month.JANUARY, 1));
 
 		assertThat(arkivbildarStruktur.getArkivbildare().getArkivbildare().getNamn()).isEqualTo("Stadsbyggnadsnämnden");
 		assertThat(arkivbildarStruktur.getArkivbildare().getArkivbildare().getVerksamhetstidFran()).isEqualTo("1993");
@@ -299,13 +300,13 @@ class ArchiverMapperTest {
 
 	@Test
 	void testToIsoDateLocalDate() {
-		assertThat(ArchiverMapper.toIsoDate(LocalDate.of(2023, 1, 1))).isEqualTo("2023-01-01");
+		assertThat(ArchiverMapper.toIsoDate(LocalDate.of(2023, Month.JANUARY, 1))).isEqualTo("2023-01-01");
 		assertThat(ArchiverMapper.toIsoDate((LocalDate) null)).isNull();
 	}
 
 	@Test
 	void testToIsoDateLocalDateTime() {
-		assertThat(ArchiverMapper.toIsoDate(LocalDate.of(2023, 1, 1).atStartOfDay())).isEqualTo("2023-01-01");
+		assertThat(ArchiverMapper.toIsoDate(LocalDate.of(2023, Month.JANUARY, 1).atStartOfDay())).isEqualTo("2023-01-01");
 		assertThat(ArchiverMapper.toIsoDate((LocalDateTime) null)).isNull();
 	}
 
@@ -322,9 +323,9 @@ class ArchiverMapperTest {
 			.withArendeId(1)
 			.withDnr("arendeId")
 			.withArendetyp("arendeTyp")
-			.withAnkomstDatum(LocalDate.of(2023, 1, 1))
-			.withRegistreradDatum(LocalDate.of(2022, 1, 2))
-			.withSlutDatum(LocalDate.of(2023, 1, 3))
+			.withAnkomstDatum(LocalDate.of(2023, Month.JANUARY, 1))
+			.withRegistreradDatum(LocalDate.of(2022, Month.JANUARY, 2))
+			.withSlutDatum(LocalDate.of(2023, Month.JANUARY, 3))
 			.withBeskrivning("beskrivning")
 			.withObjektLista(new ArrayOfAbstractArendeObjekt2()
 				.withAbstractArendeObjekt(new ArendeFastighet().withArendeObjektId(1))
@@ -332,7 +333,7 @@ class ArchiverMapperTest {
 			.withStatus("Stängt");
 
 		final var handling = new Handling()
-			.withHandlingDatum(LocalDate.of(2023, 1, 1))
+			.withHandlingDatum(LocalDate.of(2023, Month.JANUARY, 1))
 			.withAnteckning("anteckning")
 			.withTyp("handlingstyp")
 			.withDokument(new Dokument().withDokId("dokId")

--- a/src/test/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapperTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapperTest.java
@@ -20,6 +20,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import se.sundsvall.byggrarchiver.integration.db.model.ArchiveFailure;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
+import se.sundsvall.byggrarchiver.integration.db.model.BatchHistory;
 import se.sundsvall.byggrarchiver.service.exceptions.ApplicationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,7 +61,15 @@ class ArchiverMapperTest {
 
 	@Test
 	void testToArchiveFailure() {
-		final var archiveFailure = ArchiverMapper.toArchiveFailure(ARCHIVE_ERROR, "caseId", "documentId", "documentName", 5L, "2281", "message", "detail");
+		final var archiveHistory = ArchiveHistory.builder()
+			.withCaseId("caseId")
+			.withDocumentId("documentId")
+			.withDocumentName("documentName")
+			.withMunicipalityId("2281")
+			.withBatchHistory(BatchHistory.builder().withId(5L).build())
+			.build();
+
+		final var archiveFailure = ArchiverMapper.toArchiveFailure(ARCHIVE_ERROR, archiveHistory, "message", "detail");
 
 		assertThat(archiveFailure.getFailureCategory()).isEqualTo(ARCHIVE_ERROR);
 		assertThat(archiveFailure.getCaseId()).isEqualTo("caseId");
@@ -74,11 +84,30 @@ class ArchiverMapperTest {
 	}
 
 	@Test
-	void testToArchiveFailureTruncatesMessage() {
-		final var longMessage = "a".repeat(300);
+	void testToArchiveFailureWithNullBatchHistory() {
+		final var archiveHistory = ArchiveHistory.builder().withCaseId("caseId").build();
 
-		final var archiveFailure = ArchiverMapper.toArchiveFailure(ARCHIVE_ERROR, "caseId", "documentId", "documentName", 5L, "2281", longMessage, null);
+		final var archiveFailure = ArchiverMapper.toArchiveFailure(ARCHIVE_ERROR, archiveHistory, "message", "detail");
 
+		assertThat(archiveFailure.getBatchHistoryId()).isNull();
+		assertThat(archiveFailure.getCaseId()).isEqualTo("caseId");
+	}
+
+	@Test
+	void testToArchiveFailureTruncatesVarcharFields() {
+		final var longValue = "a".repeat(300);
+		final var archiveHistory = ArchiveHistory.builder()
+			.withCaseId("caseId")
+			.withDocumentId("documentId")
+			.withDocumentName(longValue)
+			.withMunicipalityId("2281")
+			.withBatchHistory(BatchHistory.builder().withId(5L).build())
+			.build();
+
+		final var archiveFailure = ArchiverMapper.toArchiveFailure(ARCHIVE_ERROR, archiveHistory, longValue, null);
+
+		// varchar(255) fields are truncated; detail (longtext) is left intact
+		assertThat(archiveFailure.getDocumentName()).hasSize(255);
 		assertThat(archiveFailure.getMessage()).hasSize(255);
 		assertThat(archiveFailure.getDetail()).isNull();
 	}

--- a/src/test/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapperTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/mapper/ArchiverMapperTest.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import se.sundsvall.byggrarchiver.integration.db.model.ArchiveFailure;
 import se.sundsvall.byggrarchiver.service.exceptions.ApplicationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,6 +29,7 @@ import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.BIL;
 import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.FAS;
 import static se.sundsvall.byggrarchiver.api.model.enums.AttachmentCategory.FASSIT2;
 import static se.sundsvall.byggrarchiver.api.model.enums.BatchTrigger.SCHEDULED;
+import static se.sundsvall.byggrarchiver.api.model.enums.FailureCategory.ARCHIVE_ERROR;
 import static se.sundsvall.byggrarchiver.testutils.TestUtil.createBatchHistory;
 import static se.sundsvall.byggrarchiver.testutils.TestUtil.createRandomArchiveHistory;
 import static se.sundsvall.byggrarchiver.testutils.TestUtil.createRandomBatchHistory;
@@ -53,6 +55,67 @@ class ArchiverMapperTest {
 		assertThat(archiveHistory.getDocumentId()).isEqualTo("dokId");
 		assertThat(archiveHistory.getDocumentType()).isEqualTo(FASSIT2.getDescription());
 		assertThat(archiveHistory.getMunicipalityId()).isEqualTo("2281");
+	}
+
+	@Test
+	void testToArchiveFailure() {
+		final var archiveFailure = ArchiverMapper.toArchiveFailure(ARCHIVE_ERROR, "caseId", "documentId", "documentName", 5L, "2281", "message", "detail");
+
+		assertThat(archiveFailure.getFailureCategory()).isEqualTo(ARCHIVE_ERROR);
+		assertThat(archiveFailure.getCaseId()).isEqualTo("caseId");
+		assertThat(archiveFailure.getDocumentId()).isEqualTo("documentId");
+		assertThat(archiveFailure.getDocumentName()).isEqualTo("documentName");
+		assertThat(archiveFailure.getBatchHistoryId()).isEqualTo(5L);
+		assertThat(archiveFailure.getMunicipalityId()).isEqualTo("2281");
+		assertThat(archiveFailure.getMessage()).isEqualTo("message");
+		assertThat(archiveFailure.getDetail()).isEqualTo("detail");
+		assertThat(archiveFailure.getId()).isNull();
+		assertThat(archiveFailure.getTimestamp()).isNull();
+	}
+
+	@Test
+	void testToArchiveFailureTruncatesMessage() {
+		final var longMessage = "a".repeat(300);
+
+		final var archiveFailure = ArchiverMapper.toArchiveFailure(ARCHIVE_ERROR, "caseId", "documentId", "documentName", 5L, "2281", longMessage, null);
+
+		assertThat(archiveFailure.getMessage()).hasSize(255);
+		assertThat(archiveFailure.getDetail()).isNull();
+	}
+
+	@Test
+	void testMapToArchiveFailureResponse() {
+		final var entity = ArchiveFailure.builder()
+			.withId(1L)
+			.withBatchHistoryId(5L)
+			.withCaseId("caseId")
+			.withDocumentId("documentId")
+			.withMunicipalityId("2281")
+			.withDocumentName("documentName")
+			.withFailureCategory(ARCHIVE_ERROR)
+			.withMessage("message")
+			.withDetail("detail")
+			.withTimestamp(LocalDateTime.of(2023, 1, 1, 12, 0))
+			.build();
+
+		final var response = ArchiverMapper.mapToArchiveFailureResponse(entity);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getId()).isEqualTo(1L);
+		assertThat(response.getBatchHistoryId()).isEqualTo(5L);
+		assertThat(response.getCaseId()).isEqualTo("caseId");
+		assertThat(response.getDocumentId()).isEqualTo("documentId");
+		assertThat(response.getMunicipalityId()).isEqualTo("2281");
+		assertThat(response.getDocumentName()).isEqualTo("documentName");
+		assertThat(response.getFailureCategory()).isEqualTo(ARCHIVE_ERROR);
+		assertThat(response.getMessage()).isEqualTo("message");
+		assertThat(response.getDetail()).isEqualTo("detail");
+		assertThat(response.getTimestamp()).isEqualTo(LocalDateTime.of(2023, 1, 1, 12, 0));
+	}
+
+	@Test
+	void testMapToArchiveFailureResponseWithNull() {
+		assertThat(ArchiverMapper.mapToArchiveFailureResponse(null)).isNull();
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/byggrarchiver/service/scheduler/ArchiverSchedulerTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/scheduler/ArchiverSchedulerTest.java
@@ -1,11 +1,14 @@
 package se.sundsvall.byggrarchiver.service.scheduler;
 
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneId;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import se.sundsvall.byggrarchiver.api.model.BatchHistoryResponse;
@@ -20,21 +23,28 @@ import static se.sundsvall.byggrarchiver.testutils.TestUtil.randomLong;
 @ExtendWith(MockitoExtension.class)
 class ArchiverSchedulerTest {
 
+	private static final LocalDate TODAY = LocalDate.of(2024, Month.JANUARY, 16);
+	private static final Clock CLOCK = Clock.fixed(TODAY.atStartOfDay(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+
 	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
 	private SchedulerProperties mockSchedulerProperties;
 
 	@Mock
 	private ByggrArchiverService mockByggrArchiverService;
 
-	@InjectMocks
 	private ArchiverScheduler archiverScheduler;
+
+	@BeforeEach
+	void setup() {
+		archiverScheduler = new ArchiverScheduler(mockByggrArchiverService, mockSchedulerProperties, CLOCK);
+	}
 
 	@Test
 	void archive() {
-		var originalStart = LocalDate.now().minusDays(7);
-		var end = LocalDate.now().minusDays(1);
-		var batchTrigger = BatchTrigger.SCHEDULED;
-		var municipalityId = "2281";
+		final var originalStart = TODAY.minusDays(7);
+		final var end = TODAY.minusDays(1);
+		final var batchTrigger = BatchTrigger.SCHEDULED;
+		final var municipalityId = "2281";
 
 		when(mockSchedulerProperties.municipalityIds()).thenReturn(List.of(municipalityId));
 

--- a/src/test/java/se/sundsvall/byggrarchiver/service/util/LocalDateAdapterTests.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/util/LocalDateAdapterTests.java
@@ -1,6 +1,7 @@
 package se.sundsvall.byggrarchiver.service.util;
 
 import java.time.LocalDate;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 import se.sundsvall.byggrarchiver.util.LocalDateAdapter;
 
@@ -31,7 +32,7 @@ class LocalDateAdapterTests {
 
 	@Test
 	void testMarshalWithNonNullInput() {
-		final var result = localDateAdapter.marshal(LocalDate.of(2023, 12, 24));
+		final var result = localDateAdapter.marshal(LocalDate.of(2023, Month.DECEMBER, 24));
 
 		assertThat(result).isEqualTo("2023-12-24");
 	}

--- a/src/test/java/se/sundsvall/byggrarchiver/service/util/LocalDateTimeAdapterTests.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/service/util/LocalDateTimeAdapterTests.java
@@ -1,6 +1,7 @@
 package se.sundsvall.byggrarchiver.service.util;
 
 import java.time.LocalDateTime;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 import se.sundsvall.byggrarchiver.util.LocalDateTimeAdapter;
 
@@ -34,7 +35,7 @@ class LocalDateTimeAdapterTests {
 
 	@Test
 	void testMarshalWithNonNullInput() {
-		final var result = localDateTimeAdapter.marshal(LocalDateTime.of(2011, 12, 3, 10, 15, 30));
+		final var result = localDateTimeAdapter.marshal(LocalDateTime.of(2011, Month.DECEMBER, 3, 10, 15, 30));
 
 		assertThat(result).isEqualTo("2011-12-03T10:15:30");
 	}

--- a/src/test/java/se/sundsvall/byggrarchiver/testutils/TestUtil.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/testutils/TestUtil.java
@@ -2,6 +2,7 @@ package se.sundsvall.byggrarchiver.testutils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import se.sundsvall.byggrarchiver.api.model.BatchHistoryResponse;
@@ -24,7 +25,7 @@ public final class TestUtil {
 			.withDocumentName(UUID.randomUUID().toString().substring(0, 21))
 			.withDocumentType(UUID.randomUUID().toString().substring(0, 21))
 			.withCaseId(UUID.randomUUID().toString())
-			.withTimestamp(LocalDateTime.now())
+			.withTimestamp(LocalDateTime.of(2024, Month.JANUARY, 16, 12, 0))
 			.build();
 	}
 
@@ -32,9 +33,9 @@ public final class TestUtil {
 		return BatchHistory.builder()
 			.withId(randomLong())
 			.withBatchTrigger(getRandomEnumValue(BatchTrigger.class))
-			.withStart(LocalDate.now())
-			.withEnd(LocalDate.now())
-			.withTimestamp(LocalDateTime.now())
+			.withStart(LocalDate.of(2024, Month.JANUARY, 16))
+			.withEnd(LocalDate.of(2024, Month.JANUARY, 16))
+			.withTimestamp(LocalDateTime.of(2024, Month.JANUARY, 16, 12, 0))
 			.withArchiveStatus(getRandomEnumValue(ArchiveStatus.class))
 			.build();
 	}
@@ -43,9 +44,9 @@ public final class TestUtil {
 		return BatchHistoryResponse.builder()
 			.withId(randomLong())
 			.withBatchTrigger(getRandomEnumValue(BatchTrigger.class))
-			.withStart(LocalDate.now())
-			.withEnd(LocalDate.now())
-			.withTimestamp(LocalDateTime.now())
+			.withStart(LocalDate.of(2024, Month.JANUARY, 16))
+			.withEnd(LocalDate.of(2024, Month.JANUARY, 16))
+			.withTimestamp(LocalDateTime.of(2024, Month.JANUARY, 16, 12, 0))
 			.withArchiveStatus(getRandomEnumValue(ArchiveStatus.class))
 			.build();
 	}

--- a/src/test/resources/db/schema.sql
+++ b/src/test/resources/db/schema.sql
@@ -1,4 +1,18 @@
 
+    create table archive_failure (
+        batch_history_id bigint not null,
+        id bigint not null auto_increment,
+        timestamp datetime(6) not null,
+        case_id varchar(255) not null,
+        detail longtext,
+        document_id varchar(255),
+        document_name varchar(255),
+        message varchar(255),
+        municipality_id varchar(255),
+        failure_category varchar(255) not null,
+        primary key (id)
+    ) engine=InnoDB;
+
     create table archive_history (
         batch_history_id bigint not null,
         timestamp datetime(6) not null,
@@ -24,19 +38,28 @@
         primary key (id)
     ) engine=InnoDB;
 
-    create index archive_history_municipality_id_idx 
+    create index archive_failure_batch_history_id_idx
+       on archive_failure (batch_history_id);
+
+    create index archive_failure_municipality_id_idx
+       on archive_failure (municipality_id);
+
+    create index archive_failure_failure_category_idx
+       on archive_failure (failure_category);
+
+    create index archive_history_municipality_id_idx
        on archive_history (municipality_id);
 
-    create index archive_history_archive_status_idx 
+    create index archive_history_archive_status_idx
        on archive_history (archive_status);
 
-    create index batch_history_municipality_id_idx 
+    create index batch_history_municipality_id_idx
        on batch_history (municipality_id);
 
-    create index batch_history_archive_status_idx 
+    create index batch_history_archive_status_idx
        on batch_history (archive_status);
 
-    alter table if exists archive_history 
-       add constraint fk_archive_history_batch_history_id 
-       foreign key (batch_history_id) 
+    alter table if exists archive_history
+       add constraint fk_archive_history_batch_history_id
+       foreign key (batch_history_id)
        references batch_history (id);

--- a/src/test/resources/db/schema.sql
+++ b/src/test/resources/db/schema.sql
@@ -3,7 +3,7 @@
         batch_history_id bigint not null,
         id bigint not null auto_increment,
         timestamp datetime(6) not null,
-        case_id varchar(255) not null,
+        case_id varchar(255),
         detail longtext,
         document_id varchar(255),
         document_name varchar(255),


### PR DESCRIPTION
Add an append-only archive_failure table recording why archiving a ByggR document fails, so operators can see what went wrong per document/batch. A dedicated table (not columns on ArchiveHistory) is used because ArchiveHistoryService.archive deletes and recreates NOT_COMPLETED ArchiveHistory rows on every batch pass/rerun, which would wipe a reason stored there exactly when debugging.

- ArchiveFailure entity + repository + V1_3 migration (no FK on batch_history_id; the audit ledger must never be blocked or cascade-deleted)
- ArchiveFailureRecorder: best-effort, never throws into the pipeline
- ArchiveFailureService.persist: REQUIRES_NEW so the audit row commits independently of surrounding rollbacks
- Record at four sites: file too large, archive reject/error, ByggR fetch fault, metadata/marshal error
- GET /{municipalityId}/batch-jobs/{batchHistoryId}/fallout endpoint

Behavior change: getDocument throws a Problem (RuntimeException) that the existing catch(ApplicationException) did not catch, aborting the whole batch. It is now caught at the fetch site, recorded as BYGGR_FETCH_ERROR, and the batch continues.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
