### PR TITLE
fix: stop archive circuit breaker opening on document-format rejections

### DIFF
--- a/src/main/java/se/sundsvall/byggrarchiver/integration/archive/ArchiveFormatRejectionPredicate.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/integration/archive/ArchiveFormatRejectionPredicate.java
@@ -1,0 +1,43 @@
+package se.sundsvall.byggrarchiver.integration.archive;
+
+import java.util.List;
+import java.util.function.Predicate;
+import se.sundsvall.dept44.exception.ServerProblem;
+
+/**
+ * Decides whether a throwable from the Archive integration is a per-document content/format rejection rather than an
+ * outage.
+ * <p>
+ * The Archive service answers HTTP 500 (mapped to {@link ServerProblem}) when it rejects a single document's
+ * file format. That is a business condition, not unavailability, so it must not count toward the {@code archive}
+ * circuit breaker / retry - otherwise a few bad documents in a batch open the breaker and block archiving of valid
+ * ones. Wired in via {@code resilience4j.*.instances.archive.ignore-exception-predicate} (resilience4j instantiates
+ * this class reflectively, hence the public no-arg constructor).
+ * <p>
+ * NOTE: workaround for the Archive service using 500 where it should use a 4xx (422) for content validation. Once the
+ * Archive service returns 4xx, this predicate and the {@link #isFormatRejection(String)} matching in
+ * {@code ArchiveAttachmentService} become dead code and should be removed.
+ */
+public final class ArchiveFormatRejectionPredicate implements Predicate<Throwable> {
+
+	private static final List<String> FORMAT_REJECTION_MARKERS = List.of(
+		"extension must be valid",
+		"File format",
+		"PreservationObjectConversionException");
+
+	/**
+	 * @param  message the exception message to inspect (typically {@code Problem.getMessage()})
+	 * @return         true if the message indicates the Archive service rejected the document's format/extension
+	 */
+	public static boolean isFormatRejection(final String message) {
+		return (message != null) && FORMAT_REJECTION_MARKERS.stream().anyMatch(message::contains);
+	}
+
+	@Override
+	public boolean test(final Throwable throwable) {
+		// Only a ServerProblem (5xx) is the misreported business 500. ClientProblem (4xx) is already ignored by the
+		// breaker/retry ignore-exceptions list, and genuine outage 500s won't carry a format-rejection marker.
+		return (throwable instanceof final ServerProblem serverProblem) && isFormatRejection(serverProblem.getMessage());
+	}
+
+}

--- a/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentService.java
+++ b/src/main/java/se/sundsvall/byggrarchiver/service/ArchiveAttachmentService.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import se.sundsvall.byggrarchiver.configuration.LongTermArchiveProperties;
+import se.sundsvall.byggrarchiver.integration.archive.ArchiveFormatRejectionPredicate;
 import se.sundsvall.byggrarchiver.integration.archive.ArchiveIntegration;
 import se.sundsvall.byggrarchiver.integration.db.ArchiveHistoryRepository;
 import se.sundsvall.byggrarchiver.integration.db.model.ArchiveHistory;
@@ -77,9 +78,7 @@ public class ArchiveAttachmentService {
 		} catch (final ClientProblem | ServerProblem e) {
 			LOG.error("Request to Archive failed. Continue with the rest.", e);
 
-			final var formatRejection = e.getMessage().contains("extension must be valid") ||
-				e.getMessage().contains("File format") ||
-				e.getMessage().contains("PreservationObjectConversionException");
+			final var formatRejection = ArchiveFormatRejectionPredicate.isFormatRejection(e.getMessage());
 
 			if (formatRejection) {
 				LOG.debug("The problem was related to the file extension. Send email with the information.");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,9 @@ resilience4j.circuitbreaker:
     archive:
       ignore-exceptions:
         - se.sundsvall.dept44.exception.ClientProblem
+      # Archive returns 500 (should be 422) for per-document content/format rejection - a business
+      # condition, not an outage. Don't let it open the breaker. Remove when Archive returns 4xx.
+      ignore-exception-predicate: se.sundsvall.byggrarchiver.integration.archive.ArchiveFormatRejectionPredicate
     messaging:
       ignore-exceptions:
         - se.sundsvall.dept44.exception.ClientProblem
@@ -21,6 +24,8 @@ resilience4j.retry:
     archive:
       ignore-exceptions:
         - se.sundsvall.dept44.exception.ClientProblem
+      # Retrying a deterministic format rejection never succeeds and re-uploads the payload each attempt. See breaker note.
+      ignore-exception-predicate: se.sundsvall.byggrarchiver.integration.archive.ArchiveFormatRejectionPredicate
     messaging:
       ignore-exceptions:
         - se.sundsvall.dept44.exception.ClientProblem

--- a/src/test/java/se/sundsvall/byggrarchiver/integration/archive/ArchiveFormatRejectionPredicateTest.java
+++ b/src/test/java/se/sundsvall/byggrarchiver/integration/archive/ArchiveFormatRejectionPredicateTest.java
@@ -1,0 +1,67 @@
+package se.sundsvall.byggrarchiver.integration.archive;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import se.sundsvall.dept44.exception.ClientProblem;
+import se.sundsvall.dept44.exception.ServerProblem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+class ArchiveFormatRejectionPredicateTest {
+
+	private final ArchiveFormatRejectionPredicate predicate = new ArchiveFormatRejectionPredicate();
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"The file extension must be valid",
+		"File format validation failed.",
+		"... PreservationObjectConversionException ...",
+		"[500 ...] [FormpipeProxyClient#postImport]: [{\"Message\":\"File format validation failed.\"}]"
+	})
+	void isFormatRejectionMatchesMarkers(final String message) {
+		assertThat(ArchiveFormatRejectionPredicate.isFormatRejection(message)).isTrue();
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = {
+		"Internal Server Error",
+		"Connection reset",
+		"Some other archive failure"
+	})
+	void isFormatRejectionDoesNotMatchOtherMessages(final String message) {
+		assertThat(ArchiveFormatRejectionPredicate.isFormatRejection(message)).isFalse();
+	}
+
+	@Test
+	void testIgnoresFormatRejectionServerProblem() {
+		final var problem = new ServerProblem(INTERNAL_SERVER_ERROR, "File format validation failed.");
+
+		assertThat(predicate.test(problem)).isTrue();
+	}
+
+	@Test
+	void testCountsGenericServerProblem() {
+		final var problem = new ServerProblem(INTERNAL_SERVER_ERROR, "Archive is down");
+
+		assertThat(predicate.test(problem)).isFalse();
+	}
+
+	@Test
+	void testLeavesClientProblemToTheIgnoreExceptionsList() {
+		// A ClientProblem (4xx) is handled by ignore-exceptions, not this predicate - even when it carries marker text.
+		final var problem = new ClientProblem(BAD_REQUEST, "File format is not allowed");
+
+		assertThat(predicate.test(problem)).isFalse();
+	}
+
+	@Test
+	void testCountsUnrelatedThrowable() {
+		assertThat(predicate.test(new RuntimeException("File format"))).isFalse();
+	}
+
+}


### PR DESCRIPTION
The Archive service returns HTTP 500 (mapped to ServerProblem) when it rejects a single document's file format - a per-document business condition, not an outage. The archive breaker only ignored ClientProblem (4xx), so these 500s counted as failures; a few rejected documents in a batch opened the breaker and blocked archiving of the remaining valid documents.

Add an ignore-exception-predicate (ArchiveFormatRejectionPredicate) to the archive circuit breaker and retry instances. It ignores only a ServerProblem whose message carries a format-rejection marker; genuine 500s, timeouts and connection failures still trip the breaker. Retry is included because retrying a deterministic rejection never succeeds and re-uploads the payload each attempt.

The format-rejection substring set is centralized in the predicate and reused by ArchiveAttachmentService so the breaker and the service catch cannot diverge.

This is a workaround for the Archive service using 500 where a 4xx (422) is correct for content validation; remove once Archive returns 4xx.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [ ] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
